### PR TITLE
Refactor/Extract presentation logic from insightsView to insightsViewModel

### DIFF
--- a/RiyaazPal.xcodeproj/project.pbxproj
+++ b/RiyaazPal.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C066A2A42F159C39005A5D44 /* ReflectionInsightService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C066A2A32F159C39005A5D44 /* ReflectionInsightService.swift */; };
 		C066A2A82F159EDB005A5D44 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C066A2A72F159EDB005A5D44 /* Secrets.swift */; };
 		C066A2AC2F15B868005A5D44 /* ReflectionInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C066A2AB2F15B868005A5D44 /* ReflectionInsightsSection.swift */; };
+		C066A2B02F18893E005A5D44 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C066A2AF2F18893E005A5D44 /* InsightsViewModel.swift */; };
 		C0A430BD2F03494200C2401C /* RiyaazPalApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430BC2F03494200C2401C /* RiyaazPalApp.swift */; };
 		C0A430BF2F03494200C2401C /* PracticeTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430BE2F03494200C2401C /* PracticeTimelineView.swift */; };
 		C0A430C12F03494400C2401C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0A430C02F03494400C2401C /* Assets.xcassets */; };
@@ -54,6 +55,7 @@
 		C066A2A32F159C39005A5D44 /* ReflectionInsightService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionInsightService.swift; sourceTree = "<group>"; };
 		C066A2A72F159EDB005A5D44 /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		C066A2AB2F15B868005A5D44 /* ReflectionInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionInsightsSection.swift; sourceTree = "<group>"; };
+		C066A2AF2F18893E005A5D44 /* InsightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
 		C0A430B92F03494200C2401C /* RiyaazPal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RiyaazPal.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0A430BC2F03494200C2401C /* RiyaazPalApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiyaazPalApp.swift; sourceTree = "<group>"; };
 		C0A430BE2F03494200C2401C /* PracticeTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimelineView.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 			children = (
 				C0A430D42F0599CD00C2401C /* PracticeSessionViewModel.swift */,
 				C0A430DE2F060DD300C2401C /* PracticeTimelineViewModel.swift */,
+				C066A2AF2F18893E005A5D44 /* InsightsViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -309,6 +312,7 @@
 				C066A2AC2F15B868005A5D44 /* ReflectionInsightsSection.swift in Sources */,
 				C0A430DB2F059A0600C2401C /* DaySection.swift in Sources */,
 				C066A2982F104854005A5D44 /* ConsistencyStats.swift in Sources */,
+				C066A2B02F18893E005A5D44 /* InsightsViewModel.swift in Sources */,
 				C066A2962F0FAE24005A5D44 /* FocusCarousel.swift in Sources */,
 				C0A430CF2F05993400C2401C /* PracticeSession.swift in Sources */,
 				C0A430ED2F098F5000C2401C /* PreviewModelContainer.swift in Sources */,

--- a/RiyaazPal/Analytics/ReflectionInsightService.swift
+++ b/RiyaazPal/Analytics/ReflectionInsightService.swift
@@ -115,9 +115,6 @@ private extension ReflectionInsightService {
         let (data, response) = try await URLSession.shared.data(for: request)
 
         let status = (response as? HTTPURLResponse)?.statusCode ?? -1
-
-
-        let text = String(decoding: data, as: UTF8.self)
         
         guard status == 200 else {
             throw URLError(.badServerResponse)

--- a/RiyaazPal/ViewModels/InsightsViewModel.swift
+++ b/RiyaazPal/ViewModels/InsightsViewModel.swift
@@ -1,0 +1,98 @@
+//
+//  InsightsViewModel.swift
+//  RiyaazPal
+//
+//  Created by Hriday Buddhdev on 2026-01-14.
+//
+
+import Foundation
+import SwiftData
+
+final class InsightsViewModel: ObservableObject {
+    
+    @Published var currentWindow: DateRange = InsightWindowHelper.dateRange()
+    
+    @Published var reflectionInsight: ReflectionInsight?
+    @Published var isLoadingInsight = false
+    @Published var insightError: String?
+    
+    func recentSessions(from sessions: [PracticeSession]) -> [PracticeSession] {
+        InsightWindowHelper.sessionsInWindow(sessions)
+    }
+    
+    func focusStats(from sessions: [PracticeSession]) -> FocusStats {
+        FocusStatsCalculator.compute(sessions: sessions)
+    }
+    
+    func consistencyStats(
+        from sessions: [PracticeSession]
+    ) -> ConsistencyStats {
+        ConsistencyStatsCalculator.compute(
+            sessions: sessions,
+            dateRange: currentWindow
+        )
+    }
+    
+    func patterns(
+        from sessions: [PracticeSession],
+        focusStats: FocusStats
+    ) -> [PracticePattern] {
+        PracticePatternCalculator.compute(
+            sessions: sessions,
+            focusStats: focusStats
+        )
+    }
+    
+    func practiceScore(
+        consistency: ConsistencyStats,
+        patterns: [PracticePattern]
+    ) -> Int {
+        PracticeScoreCalculator.compute(
+            consistency: consistency,
+            patterns: patterns
+        )
+    }
+    
+    
+    @MainActor
+    func fetchReflectionInsight(
+        sessions: [PracticeSession]
+    ) async {
+        guard !sessions.isEmpty else { return }
+        
+        isLoadingInsight = true
+        insightError = nil
+        
+        do {
+            let insight = try await ReflectionInsightService.generateInsight(
+                sessions: sessions,
+                window: currentWindow
+            )
+            
+            reflectionInsight = insight
+        } catch {
+            insightError = "Unable to analyze reflections. Please try again."
+            reflectionInsight = nil
+        }
+        
+        isLoadingInsight = false
+    }
+    
+    func insightsVersion(
+        recentSessions: [PracticeSession]
+    ) -> InsightsVersion {
+        InsightsVersion(
+            sessionCount: recentSessions.count,
+            lastModified: recentSessions.map(\.lastModified).max(),
+            rangeStart: currentWindow.start,
+            rangeEnd: currentWindow.end
+        )
+    }
+}
+
+struct InsightsVersion: Hashable {
+    let sessionCount: Int
+    let lastModified: Date?
+    let rangeStart: Date
+    let rangeEnd: Date
+}

--- a/RiyaazPal/Views/Insights/InsightsView.swift
+++ b/RiyaazPal/Views/Insights/InsightsView.swift
@@ -13,36 +13,28 @@ struct InsightsView: View {
     @Query(sort: \PracticeSession.startTime, order: .reverse)
         private var sessions: [PracticeSession]
     
-    @State private var reflectionInsight: ReflectionInsight?
-    @State private var isLoadingInsight = false
-    @State private var insightError: String?
     
-    @State private var currentWindow: DateRange = InsightWindowHelper.dateRange()
+    @State private var insightsViewModel = InsightsViewModel()
     
     private var recentSessions: [PracticeSession] {
-        InsightWindowHelper.sessionsInWindow(sessions)
+        insightsViewModel.recentSessions(from: sessions)
     }
 
     private var focusStats: FocusStats {
-        FocusStatsCalculator.compute(sessions: recentSessions)
+        insightsViewModel.focusStats(from: recentSessions)
     }
     
     private var consistencyStats: ConsistencyStats {
-        ConsistencyStatsCalculator.compute(sessions: recentSessions, dateRange: currentWindow)
+        insightsViewModel.consistencyStats(from: recentSessions)
     }
     
     private var patterns: [PracticePattern] {
-        PracticePatternCalculator.compute(sessions: recentSessions, focusStats: focusStats)
+        insightsViewModel.patterns(from: recentSessions, focusStats: focusStats)
     }
     
     private var practiceScore: Int {
-        PracticeScoreCalculator.compute(
-            consistency: consistencyStats,
-            patterns: patterns
-        )
+        insightsViewModel.practiceScore(consistency: consistencyStats, patterns: patterns)
     }
-
-    
 
     
     var body: some View {
@@ -53,21 +45,23 @@ struct InsightsView: View {
             ScrollView {
                 VStack(spacing: 12) {
                     header
-                    practiceScoreCard
+                    PracticeScoreMeter(
+                        score: practiceScore
+                    )
                     FocusCarousel(focusStats: focusStats)
                     consistencySummary
                     notablePatterns
                     ReflectionInsightSection(
-                        insight: reflectionInsight,
-                        isLoading: isLoadingInsight,
-                        error: insightError
+                        insight: insightsViewModel.reflectionInsight,
+                        isLoading: insightsViewModel.isLoadingInsight,
+                        error: insightsViewModel.insightError
                     )
 
                 }
                 .padding()
             }
         }.task(id: insightsVersion) {
-            await fetchReflectionInsight()
+            await insightsViewModel.fetchReflectionInsight(sessions: recentSessions)
         }
 
         .navigationTitle("Insights")
@@ -90,37 +84,6 @@ private extension InsightsView {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
-
-private extension InsightsView {
-    var practiceScoreCard: some View {
-        PracticeScoreMeter(
-            score: practiceScore
-        )
-    }
-    
-    private func fetchReflectionInsight() async {
-        guard !recentSessions.isEmpty else { return }
-
-        isLoadingInsight = true
-        insightError = nil
-
-        do {
-            let insight = try await ReflectionInsightService.generateInsight(
-                sessions: recentSessions,
-                window: currentWindow
-            )
-
-            reflectionInsight = insight
-        } catch {
-            insightError = "Unable to analyze reflections. Please try again."
-            reflectionInsight = nil
-        }
-
-        isLoadingInsight = false
-    }
-
-}
-
 
 private extension InsightsView {
     var consistencySummary: some View {
@@ -211,27 +174,16 @@ private extension InsightsView {
         formatter.dateStyle = .medium
         formatter.timeStyle = .none
 
-        return formatter.string(from: currentWindow.start, to: currentWindow.end)
+        return formatter.string(from: insightsViewModel.currentWindow.start, to: insightsViewModel.currentWindow.end)
     }
     
     private var insightsVersion: InsightsVersion {
-        InsightsVersion(
-            sessionCount: recentSessions.count,
-            lastModified: recentSessions.map(\.lastModified).max(),
-            rangeStart: currentWindow.start,
-            rangeEnd: currentWindow.end
+        insightsViewModel.insightsVersion(
+            recentSessions: recentSessions
         )
     }
 
 }
-
-struct InsightsVersion: Hashable {
-    let sessionCount: Int
-    let lastModified: Date?
-    let rangeStart: Date
-    let rangeEnd: Date
-}
-
 
 #Preview("Insights – Light") {
     let container = PreviewModelContainer.make()


### PR DESCRIPTION
- This refactor is purely extracting logic that calls focusStatsCalculator, PatternsCalculator etc. into a view model to follow MVVM architecture properly/ decrease the size of `InsightsView`. No other logic has been modified