### PR TITLE
Feature/Add session type to practice session (model only)

### DIFF
--- a/RiyaazPal.xcodeproj/project.pbxproj
+++ b/RiyaazPal.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		C0E580542F1EB45700571C5E /* TagCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E580532F1EB45700571C5E /* TagCategoryModel.swift */; };
 		C0F593742F1F6560009F6A0D /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F593732F1F6560009F6A0D /* ProfileView.swift */; };
 		C0F593772F1F6593009F6A0D /* CategoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F593762F1F6593009F6A0D /* CategoryDetailView.swift */; };
+		C0FFBDE42F366DED00F84DFA /* SessionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFBDE32F366DED00F84DFA /* SessionType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -108,6 +109,7 @@
 		C0E580532F1EB45700571C5E /* TagCategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCategoryModel.swift; sourceTree = "<group>"; };
 		C0F593732F1F6560009F6A0D /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		C0F593762F1F6593009F6A0D /* CategoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailView.swift; sourceTree = "<group>"; };
+		C0FFBDE32F366DED00F84DFA /* SessionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -206,6 +208,7 @@
 			children = (
 				C0A430CE2F05993400C2401C /* PracticeSession.swift */,
 				C0E580532F1EB45700571C5E /* TagCategoryModel.swift */,
+				C0FFBDE32F366DED00F84DFA /* SessionType.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -428,6 +431,7 @@
 				C0E5804C2F1B00FF00571C5E /* EditSessionViewModel.swift in Sources */,
 				C0A430BD2F03494200C2401C /* RiyaazPalApp.swift in Sources */,
 				C0E580502F1DD1EB00571C5E /* SessionActionButton.swift in Sources */,
+				C0FFBDE42F366DED00F84DFA /* SessionType.swift in Sources */,
 				C066A2A22F14F641005A5D44 /* DateTimePickerSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RiyaazPal/Models/PracticeSession.swift
+++ b/RiyaazPal/Models/PracticeSession.swift
@@ -17,6 +17,7 @@ final class PracticeSession {
     var tags: [String]
     var detailedNotes: String
     var lastModified: Date
+    var sessionType: SessionType
 
     init(
         id: UUID = UUID(),
@@ -25,7 +26,8 @@ final class PracticeSession {
         notes: String,
         tags: [String] = [],
         detailedNotes: String = "",
-        lastModified: Date = .now
+        lastModified: Date = .now,
+        sessionType: SessionType = .practice
     ) {
         self.id = id
         self.startTime = startTime
@@ -34,6 +36,8 @@ final class PracticeSession {
         self.tags = tags
         self.detailedNotes = detailedNotes
         self.lastModified = lastModified
+        self.sessionType = sessionType
+        
     }
 }
 

--- a/RiyaazPal/Models/SessionType.swift
+++ b/RiyaazPal/Models/SessionType.swift
@@ -1,0 +1,14 @@
+//
+//  SessionType.swift
+//  RiyaazPal
+//
+//  Created by Hriday Buddhdev on 2026-02-06.
+//
+
+import Foundation
+
+enum SessionType: String, Codable, CaseIterable {
+    case practice
+    case concert
+}
+


### PR DESCRIPTION
This PR adds the session type (default is practice) to the practice session model. This will pave the way for tagging a practice session as either a practice session or concert to get insights on either domain separately 