### PR TITLE
story/Add session practice area questionnaire

### DIFF
--- a/RiyaazPal.xcodeproj/project.pbxproj
+++ b/RiyaazPal.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		C0864B112F9B1000006E5F6A /* PracticeAreaModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B102F9B1000006E5F6A /* PracticeAreaModel.swift */; };
 		C0864B132F9F3000006E5F6A /* PracticeAreasViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B122F9F3000006E5F6A /* PracticeAreasViewModel.swift */; };
 		C0864B152F9F3010006E5F6A /* PracticeAreasPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B142F9F3010006E5F6A /* PracticeAreasPanel.swift */; };
+		C0864B172FA03400006E5F6A /* PracticeAreaQuestionnaireFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B162FA03400006E5F6A /* PracticeAreaQuestionnaireFlow.swift */; };
 		C091E6332F41CFAB00271B6E /* ConsistencySummarySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C091E6322F41CFAB00271B6E /* ConsistencySummarySection.swift */; };
 		C091E6352F42580200271B6E /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C091E6342F42580200271B6E /* FilterChip.swift */; };
 		C091E6372F425D1200271B6E /* PracticeTimelineTypeEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C091E6362F425D1200271B6E /* PracticeTimelineTypeEmptyState.swift */; };
@@ -111,6 +112,7 @@
 		C0864B102F9B1000006E5F6A /* PracticeAreaModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreaModel.swift; sourceTree = "<group>"; };
 		C0864B122F9F3000006E5F6A /* PracticeAreasViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreasViewModel.swift; sourceTree = "<group>"; };
 		C0864B142F9F3010006E5F6A /* PracticeAreasPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreasPanel.swift; sourceTree = "<group>"; };
+		C0864B162FA03400006E5F6A /* PracticeAreaQuestionnaireFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreaQuestionnaireFlow.swift; sourceTree = "<group>"; };
 		C091E6322F41CFAB00271B6E /* ConsistencySummarySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsistencySummarySection.swift; sourceTree = "<group>"; };
 		C091E6342F42580200271B6E /* FilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChip.swift; sourceTree = "<group>"; };
 		C091E6362F425D1200271B6E /* PracticeTimelineTypeEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimelineTypeEmptyState.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 				C0A430E22F083A2700C2401C /* EditSessionView.swift */,
 				C0FFBDE52F36722200F84DFA /* SessionTypePicker.swift */,
 				C060F7012F4EEE07008946CA /* TagSuggestionsSection.swift */,
+				C0864B162FA03400006E5F6A /* PracticeAreaQuestionnaireFlow.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -496,6 +499,7 @@
 				C0742B9E2F445749004E7697 /* GoalsPanel.swift in Sources */,
 				C0864B152F9F3010006E5F6A /* PracticeAreasPanel.swift in Sources */,
 				C0A430BF2F03494200C2401C /* PracticeTimelineView.swift in Sources */,
+				C0864B172FA03400006E5F6A /* PracticeAreaQuestionnaireFlow.swift in Sources */,
 				C04482E12F273B7A00068D74 /* CategorySetupStepView.swift in Sources */,
 				C066A2902F0F3A68005A5D44 /* FocusBreakdownCard.swift in Sources */,
 				C0A430E32F083A2700C2401C /* EditSessionView.swift in Sources */,

--- a/RiyaazPal/ViewModels/EditSessionViewModel.swift
+++ b/RiyaazPal/ViewModels/EditSessionViewModel.swift
@@ -215,7 +215,7 @@ extension EditSessionViewModel {
             .filter(\.isActive)
             .sorted { $0.order < $1.order }
 
-        practiceAreaDrafts = activeAreas.map { area in
+        let activeDrafts = activeAreas.map { area in
             if let existing = existingByAreaID[area.id] {
                 return PracticeAreaQuestionnaireDraft(
                     sessionID: session.id,
@@ -235,6 +235,20 @@ extension EditSessionViewModel {
             )
         }
 
+        let activeAreaIDs = Set(activeAreas.map(\.id))
+        let historicalDrafts = existingRatings
+            .filter { !activeAreaIDs.contains($0.practiceAreaID) }
+            .map { rating in
+                PracticeAreaQuestionnaireDraft(
+                    sessionID: session.id,
+                    practiceAreaID: rating.practiceAreaID,
+                    areaName: rating.areaName,
+                    didPractice: rating.didPractice,
+                    score: rating.score
+                )
+            }
+
+        practiceAreaDrafts = activeDrafts + historicalDrafts
         hasPracticeAreaReflection = !existingRatings.isEmpty
     }
 

--- a/RiyaazPal/ViewModels/EditSessionViewModel.swift
+++ b/RiyaazPal/ViewModels/EditSessionViewModel.swift
@@ -117,8 +117,17 @@ extension EditSessionViewModel {
             uniquingKeysWith: { first, _ in first }
         )
 
+        let ratingsByAreaName = Dictionary(
+            existingRatings.map { (Self.normalizedAreaName($0.areaName), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
         for draft in practiceAreaDrafts {
-            if let rating = ratingsByAreaID[draft.practiceAreaID] {
+            let existingRating = ratingsByAreaID[draft.practiceAreaID]
+                ?? ratingsByAreaName[Self.normalizedAreaName(draft.areaName)]
+
+            if let rating = existingRating {
+                rating.practiceAreaID = draft.practiceAreaID
                 rating.areaName = draft.areaName
                 rating.didPractice = draft.didPractice
                 rating.score = draft.didPractice ? draft.score.map(PracticeAreaRatingEntity.clampedScore) : nil
@@ -211,16 +220,24 @@ extension EditSessionViewModel {
             uniquingKeysWith: { first, _ in first }
         )
 
+        let existingByAreaName = Dictionary(
+            existingRatings.map { (Self.normalizedAreaName($0.areaName), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
         let activeAreas = practiceAreas
             .filter(\.isActive)
             .sorted { $0.order < $1.order }
 
         let activeDrafts = activeAreas.map { area in
-            if let existing = existingByAreaID[area.id] {
+            let existing = existingByAreaID[area.id]
+                ?? existingByAreaName[Self.normalizedAreaName(area.name)]
+
+            if let existing {
                 return PracticeAreaQuestionnaireDraft(
                     sessionID: session.id,
                     practiceAreaID: area.id,
-                    areaName: existing.areaName,
+                    areaName: area.name,
                     didPractice: existing.didPractice,
                     score: existing.score
                 )
@@ -236,8 +253,12 @@ extension EditSessionViewModel {
         }
 
         let activeAreaIDs = Set(activeAreas.map(\.id))
+        let activeAreaNames = Set(activeAreas.map { Self.normalizedAreaName($0.name) })
         let historicalDrafts = existingRatings
-            .filter { !activeAreaIDs.contains($0.practiceAreaID) }
+            .filter {
+                !activeAreaIDs.contains($0.practiceAreaID) &&
+                !activeAreaNames.contains(Self.normalizedAreaName($0.areaName))
+            }
             .map { rating in
                 PracticeAreaQuestionnaireDraft(
                     sessionID: session.id,
@@ -283,6 +304,10 @@ extension EditSessionViewModel {
 
     var practicedAreaCount: Int {
         practiceAreaDrafts.filter(\.didPractice).count
+    }
+
+    static func normalizedAreaName(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 

--- a/RiyaazPal/ViewModels/EditSessionViewModel.swift
+++ b/RiyaazPal/ViewModels/EditSessionViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import Combine
+import SwiftData
 
 final class EditSessionViewModel: ObservableObject {
 
@@ -20,6 +21,8 @@ final class EditSessionViewModel: ObservableObject {
     @Published var showingStartTimePicker = false
 
     @Published var suggestedTags: [String] = []
+    @Published var practiceAreaDrafts: [PracticeAreaQuestionnaireDraft] = []
+    @Published var hasPracticeAreaReflection = false
 
     private var tagProvider: CategoryTagProvider?
     private var cancellables = Set<AnyCancellable>()
@@ -103,6 +106,36 @@ extension EditSessionViewModel {
         session.confidence = draft.confidence
     }
 
+    func commitPracticeAreaRatings(
+        context: ModelContext,
+        existingRatings: [PracticeAreaRatingEntity]
+    ) {
+        guard hasPracticeAreaReflection else { return }
+
+        let ratingsByAreaID = Dictionary(
+            existingRatings.map { ($0.practiceAreaID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        for draft in practiceAreaDrafts {
+            if let rating = ratingsByAreaID[draft.practiceAreaID] {
+                rating.areaName = draft.areaName
+                rating.didPractice = draft.didPractice
+                rating.score = draft.didPractice ? draft.score.map(PracticeAreaRatingEntity.clampedScore) : nil
+                rating.lastModified = .now
+            } else {
+                let rating = PracticeAreaRatingEntity(
+                    sessionID: draft.sessionID,
+                    practiceAreaID: draft.practiceAreaID,
+                    areaName: draft.areaName,
+                    didPractice: draft.didPractice,
+                    score: draft.score
+                )
+                context.insert(rating)
+            }
+        }
+    }
+
     private func normalizeTag(_ tag: String) -> String {
         tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
@@ -167,6 +200,78 @@ extension EditSessionViewModel {
     
 }
 
+extension EditSessionViewModel {
+
+    func configurePracticeAreaQuestionnaire(
+        practiceAreas: [PracticeAreaEntity],
+        existingRatings: [PracticeAreaRatingEntity]
+    ) {
+        let existingByAreaID = Dictionary(
+            existingRatings.map { ($0.practiceAreaID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        let activeAreas = practiceAreas
+            .filter(\.isActive)
+            .sorted { $0.order < $1.order }
+
+        practiceAreaDrafts = activeAreas.map { area in
+            if let existing = existingByAreaID[area.id] {
+                return PracticeAreaQuestionnaireDraft(
+                    sessionID: session.id,
+                    practiceAreaID: area.id,
+                    areaName: existing.areaName,
+                    didPractice: existing.didPractice,
+                    score: existing.score
+                )
+            }
+
+            return PracticeAreaQuestionnaireDraft(
+                sessionID: session.id,
+                practiceAreaID: area.id,
+                areaName: area.name,
+                didPractice: false,
+                score: nil
+            )
+        }
+
+        hasPracticeAreaReflection = !existingRatings.isEmpty
+    }
+
+    func markPracticeAreaReflectionStarted() {
+        hasPracticeAreaReflection = true
+    }
+
+    func updatePracticeAreaScore(
+        for draftID: UUID,
+        score: Int
+    ) {
+        guard let index = practiceAreaDrafts.firstIndex(where: { $0.id == draftID }) else {
+            return
+        }
+
+        practiceAreaDrafts[index].didPractice = true
+        practiceAreaDrafts[index].score = PracticeAreaRatingEntity.clampedScore(score)
+        hasPracticeAreaReflection = true
+    }
+
+    func markPracticeAreaNotPracticed(
+        draftID: UUID
+    ) {
+        guard let index = practiceAreaDrafts.firstIndex(where: { $0.id == draftID }) else {
+            return
+        }
+
+        practiceAreaDrafts[index].didPractice = false
+        practiceAreaDrafts[index].score = nil
+        hasPracticeAreaReflection = true
+    }
+
+    var practicedAreaCount: Int {
+        practiceAreaDrafts.filter(\.didPractice).count
+    }
+}
+
 struct PracticeSessionDraft {
     let id: UUID
     var startTime: Date
@@ -180,5 +285,19 @@ struct PracticeSessionDraft {
     var resolvedConfidence: Int {
         get { min(max(confidence ?? 5, 1), 10) }
         set { confidence = min(max(newValue, 1), 10) }
+    }
+}
+
+struct PracticeAreaQuestionnaireDraft: Identifiable, Hashable {
+    var id: UUID { practiceAreaID }
+
+    let sessionID: UUID
+    let practiceAreaID: UUID
+    var areaName: String
+    var didPractice: Bool
+    var score: Int?
+
+    var resolvedScore: Int {
+        score ?? 5
     }
 }

--- a/RiyaazPal/Views/Session/EditSessionView.swift
+++ b/RiyaazPal/Views/Session/EditSessionView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import SwiftData 
 
 struct EditSessionView: View {
+    @Environment(\.modelContext) private var context
     @Environment(\.dismiss) private var dismiss
 
     private let session: PracticeSession
@@ -18,6 +19,13 @@ struct EditSessionView: View {
     @Query(sort: \TagCategoryModel.order)
     private var categories: [TagCategoryModel]
 
+    @Query(sort: \PracticeAreaEntity.order)
+    private var practiceAreas: [PracticeAreaEntity]
+
+    @Query(sort: \PracticeAreaRatingEntity.createdAt)
+    private var practiceAreaRatings: [PracticeAreaRatingEntity]
+
+    @State private var showPracticeAreaQuestionnaire = false
 
     init(session: PracticeSession) {
         self.session = session
@@ -84,6 +92,12 @@ struct EditSessionView: View {
                             .padding(.top, 8)
                         }
 
+                        if editSessionViewModel.draft.sessionType == .practice {
+                            reflectOnSessionButton
+                                .padding(.horizontal)
+                                .padding(.top, 20)
+                        }
+
                         EditSessionNotesEditor(
                             notes: Binding(
                                 get: { editSessionViewModel.draft.detailedNotes },
@@ -104,18 +118,53 @@ struct EditSessionView: View {
             }
             .onAppear {
                 editSessionViewModel.configureTagSource(categories: categories)
+                editSessionViewModel.configurePracticeAreaQuestionnaire(
+                    practiceAreas: practiceAreas,
+                    existingRatings: sessionPracticeAreaRatings
+                )
             }
             .background(Color("AppBackground"))
             .navigationBarTitleDisplayMode(.inline)
+            .fullScreenCover(isPresented: $showPracticeAreaQuestionnaire) {
+                PracticeAreaQuestionnaireFlow(
+                    drafts: editSessionViewModel.practiceAreaDrafts,
+                    onScoreChanged: { draftID, score in
+                        editSessionViewModel.updatePracticeAreaScore(
+                            for: draftID,
+                            score: score
+                        )
+                    },
+                    onNotPracticed: { draftID in
+                        editSessionViewModel.markPracticeAreaNotPracticed(
+                            draftID: draftID
+                        )
+                    },
+                    onDone: {
+                        showPracticeAreaQuestionnaire = false
+                    }
+                )
+                .onAppear {
+                    editSessionViewModel.markPracticeAreaReflectionStarted()
+                }
+            }
         }
     }
 }
 
 private extension EditSessionView {
+    var sessionPracticeAreaRatings: [PracticeAreaRatingEntity] {
+        practiceAreaRatings.filter { $0.sessionID == session.id }
+    }
+
     var saveAndCancelButtons: some View {
         VStack(spacing: 12) {
             Button {
                 editSessionViewModel.commit()
+                editSessionViewModel.commitPracticeAreaRatings(
+                    context: context,
+                    existingRatings: sessionPracticeAreaRatings
+                )
+                try? context.save()
                 dismiss()
             } label: {
                 Text("Save Changes")
@@ -137,6 +186,63 @@ private extension EditSessionView {
                     .foregroundStyle(Color("SecondaryText"))
             }
         }
+    }
+
+    var reflectOnSessionButton: some View {
+        Button {
+            showPracticeAreaQuestionnaire = true
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "slider.horizontal.3")
+                    .foregroundStyle(Color("AccentColor"))
+                    .frame(width: 22)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Reflect on Session")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color("PrimaryText"))
+
+                    Text(reflectionStatusText)
+                        .font(.caption)
+                        .foregroundStyle(Color("SecondaryText"))
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(Color("SecondaryText"))
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color("EditorBackground"))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color("EditorBorder"), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    var reflectionStatusText: String {
+        guard !editSessionViewModel.practiceAreaDrafts.isEmpty else {
+            return "Add practice areas from Profile"
+        }
+
+        guard editSessionViewModel.hasPracticeAreaReflection else {
+            return "Not started"
+        }
+
+        let practicedCount = editSessionViewModel.practicedAreaCount
+
+        if practicedCount == 0 {
+            return "All areas marked not practiced"
+        }
+
+        return "\(practicedCount) of \(editSessionViewModel.practiceAreaDrafts.count) areas practiced"
     }
     
     var startDateTimePicker: some View {

--- a/RiyaazPal/Views/Session/PracticeAreaQuestionnaireFlow.swift
+++ b/RiyaazPal/Views/Session/PracticeAreaQuestionnaireFlow.swift
@@ -1,0 +1,210 @@
+//
+//  PracticeAreaQuestionnaireFlow.swift
+//  RiyaazPal
+//
+//  Created by Hriday Buddhdev on 2026-05-04.
+//
+
+import Foundation
+import SwiftUI
+
+struct PracticeAreaQuestionnaireFlow: View {
+
+    let drafts: [PracticeAreaQuestionnaireDraft]
+    let onScoreChanged: (UUID, Int) -> Void
+    let onNotPracticed: (UUID) -> Void
+    let onDone: () -> Void
+
+    @State private var currentIndex = 0
+
+    private var currentDraft: PracticeAreaQuestionnaireDraft? {
+        guard drafts.indices.contains(currentIndex) else { return nil }
+        return drafts[currentIndex]
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color("AppBackground")
+                    .ignoresSafeArea()
+
+                if drafts.isEmpty {
+                    emptyState
+                } else if let currentDraft {
+                    questionContent(currentDraft)
+                }
+            }
+            .navigationTitle("Reflect")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done", action: onDone)
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+}
+
+private extension PracticeAreaQuestionnaireFlow {
+
+    var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "slider.horizontal.3")
+                .font(.largeTitle)
+                .foregroundStyle(Color("AccentColor"))
+
+            Text("No practice areas yet")
+                .font(.headline)
+                .foregroundStyle(Color("PrimaryText"))
+
+            Text("Add practice areas from Profile to reflect on them after each session.")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Color("SecondaryText"))
+                .padding(.horizontal, 28)
+        }
+    }
+
+    func questionContent(_ draft: PracticeAreaQuestionnaireDraft) -> some View {
+        VStack(spacing: 24) {
+            progressText
+
+            Spacer(minLength: 20)
+
+            VStack(spacing: 18) {
+                Text("How did \(draft.areaName) go for you today?")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(Color("PrimaryText"))
+                    .padding(.horizontal)
+
+                scorePanel(draft)
+            }
+
+            Spacer()
+
+            navigationButtons
+        }
+        .padding()
+    }
+
+    var progressText: some View {
+        Text("\(currentIndex + 1) of \(drafts.count)")
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundStyle(Color("SecondaryText"))
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    func scorePanel(_ draft: PracticeAreaQuestionnaireDraft) -> some View {
+        VStack(spacing: 18) {
+            HStack {
+                Text(draft.didPractice ? "\(draft.resolvedScore)/10" : "Not practiced today")
+                    .font(.headline)
+                    .foregroundStyle(Color("PrimaryText"))
+
+                Spacer()
+            }
+
+            Slider(
+                value: Binding(
+                    get: { Double(draft.resolvedScore) },
+                    set: { newValue in
+                        onScoreChanged(draft.id, Int(newValue))
+                    }
+                ),
+                in: 1...10,
+                step: 1
+            )
+            .tint(Color("AccentColor"))
+
+            Button {
+                onNotPracticed(draft.id)
+            } label: {
+                HStack {
+                    Image(systemName: draft.didPractice ? "circle" : "checkmark.circle.fill")
+                    Text("I didn't work on this today")
+                }
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(
+                    Capsule()
+                        .fill(draft.didPractice ? Color("EditorBackground") : Color("AccentColor").opacity(0.16))
+                )
+                .foregroundStyle(draft.didPractice ? Color("PrimaryText") : Color("AccentColor"))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color("CardBackground"))
+        )
+        .shadow(color: .black.opacity(0.08), radius: 10)
+    }
+
+    var navigationButtons: some View {
+        HStack(spacing: 12) {
+            Button {
+                currentIndex = max(0, currentIndex - 1)
+            } label: {
+                Text("Back")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(
+                        Capsule()
+                            .fill(Color("EditorBackground"))
+                    )
+            }
+            .disabled(currentIndex == 0)
+            .foregroundStyle(currentIndex == 0 ? Color("SecondaryText") : Color("PrimaryText"))
+
+            Button {
+                if currentIndex == drafts.count - 1 {
+                    onDone()
+                } else {
+                    currentIndex = min(drafts.count - 1, currentIndex + 1)
+                }
+            } label: {
+                Text(currentIndex == drafts.count - 1 ? "Done" : "Next")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(
+                        Capsule()
+                            .fill(Color("AccentColor"))
+                    )
+                    .foregroundStyle(.white)
+            }
+        }
+    }
+}
+
+#Preview("Questionnaire Flow") {
+    PracticeAreaQuestionnaireFlow(
+        drafts: [
+            PracticeAreaQuestionnaireDraft(
+                sessionID: UUID(),
+                practiceAreaID: UUID(),
+                areaName: "Sapat Taans",
+                didPractice: false,
+                score: nil
+            ),
+            PracticeAreaQuestionnaireDraft(
+                sessionID: UUID(),
+                practiceAreaID: UUID(),
+                areaName: "Layakari",
+                didPractice: true,
+                score: 7
+            )
+        ],
+        onScoreChanged: { _, _ in },
+        onNotPracticed: { _ in },
+        onDone: { }
+    )
+}


### PR DESCRIPTION
- Add session practice area questionnaire (only for practice currently but should be easily extended to concerts)
- Merge duplicate practice areas (e.g if we delete and then re add a new practice area it will merge the old inactive practice area on a session into the new one so we don't have two alaap areas for example)
- preserve inactive ratings on sessions already logged (i.e we should still keep alaap logged on an old session even when the practice area is made inactive)
- Add button to start questionnaire on editSessionView
- Add "I did not work on this today" option 
- Display how many of active practice areas were touched on this session