### PR TITLE
fix/optimize practice area insights navigation

### DIFF
--- a/RiyaazPal.xcodeproj/xcshareddata/xcschemes/RiyaazPal.xcscheme
+++ b/RiyaazPal.xcodeproj/xcshareddata/xcschemes/RiyaazPal.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C0A430B82F03494200C2401C"
+               BuildableName = "RiyaazPal.app"
+               BlueprintName = "RiyaazPal"
+               ReferencedContainer = "container:RiyaazPal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0A430B82F03494200C2401C"
+            BuildableName = "RiyaazPal.app"
+            BlueprintName = "RiyaazPal"
+            ReferencedContainer = "container:RiyaazPal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0A430B82F03494200C2401C"
+            BuildableName = "RiyaazPal.app"
+            BlueprintName = "RiyaazPal"
+            ReferencedContainer = "container:RiyaazPal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RiyaazPal/Views/Insights/PracticeAreaInsightDetailView.swift
+++ b/RiyaazPal/Views/Insights/PracticeAreaInsightDetailView.swift
@@ -22,7 +22,7 @@ struct PracticeAreaInsightDetailView: View {
                 .ignoresSafeArea()
 
             ScrollView {
-                LazyVStack(spacing: 16) {
+                VStack(spacing: 16) {
                     headerCard
                     if mode == .practice {
                         practiceTrendCard
@@ -400,7 +400,7 @@ private extension View {
                 RoundedRectangle(cornerRadius: 16)
                     .fill(background)
             )
-            .shadow(color: .black.opacity(0.06), radius: 6)
+            .shadow(color: .black.opacity(0.04), radius: 3, y: 2)
     }
 }
 

--- a/RiyaazPal/Views/Insights/PracticeAreaInsightsContent.swift
+++ b/RiyaazPal/Views/Insights/PracticeAreaInsightsContent.swift
@@ -12,26 +12,31 @@ struct PracticeAreaInsightsContent: View {
     let activePracticeAreaCount: Int
     let onManagePracticeAreas: () -> Void
 
-    private var activeMetrics: [PracticeAreaMetric] {
-        metrics.filter(\.isActive)
-    }
+    private let activeMetrics: [PracticeAreaMetric]
+    private let ratedMetrics: [PracticeAreaMetric]
+    private let attentionMetrics: [PracticeAreaMetric]
+    private let improvingMetrics: [PracticeAreaMetric]
 
-    private var ratedMetrics: [PracticeAreaMetric] {
-        metrics.filter { $0.practice.ratedSessionCount > 0 }
-    }
+    init(
+        metrics: [PracticeAreaMetric],
+        activePracticeAreaCount: Int,
+        onManagePracticeAreas: @escaping () -> Void
+    ) {
+        self.metrics = metrics
+        self.activePracticeAreaCount = activePracticeAreaCount
+        self.onManagePracticeAreas = onManagePracticeAreas
 
-    private var attentionMetrics: [PracticeAreaMetric] {
-        activeMetrics
+        let activeMetrics = metrics.filter(\.isActive)
+        self.activeMetrics = activeMetrics
+        self.ratedMetrics = metrics.filter { $0.practice.ratedSessionCount > 0 }
+        self.attentionMetrics = activeMetrics
             .filter { metric in
                 metric.isNeglected
                 || metric.trendDirection == .declining
                 || metric.performanceTransfer.status == .significantDrop
             }
-            .sorted(by: attentionSort)
-    }
-
-    private var improvingMetrics: [PracticeAreaMetric] {
-        activeMetrics
+            .sorted(by: Self.attentionSort)
+        self.improvingMetrics = activeMetrics
             .filter { $0.trendDirection == .improving }
             .sorted { lhs, rhs in
                 (lhs.sevenDayAverage ?? 0) > (rhs.sevenDayAverage ?? 0)
@@ -69,7 +74,7 @@ struct PracticeAreaInsightsContent: View {
                     )
                 }
 
-                LazyVStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 12) {
                     Text("Practice Areas")
                         .font(.headline)
                         .foregroundStyle(Color("PrimaryText"))
@@ -90,14 +95,14 @@ struct PracticeAreaInsightsContent: View {
         }
     }
 
-    private func attentionSort(
+    private static func attentionSort(
         lhs: PracticeAreaMetric,
         rhs: PracticeAreaMetric
     ) -> Bool {
         attentionScore(lhs) > attentionScore(rhs)
     }
 
-    private func attentionScore(_ metric: PracticeAreaMetric) -> Int {
+    private static func attentionScore(_ metric: PracticeAreaMetric) -> Int {
         var score = 0
         if metric.isNeglected { score += 4 }
         if metric.performanceTransfer.status == .significantDrop { score += 3 }
@@ -160,7 +165,7 @@ private struct PracticeAreaOverviewCard: View {
             }
         }
         .insightCard()
-        .shadow(color: .black.opacity(0.08), radius: 10)
+        .shadow(color: .black.opacity(0.04), radius: 3, y: 2)
     }
 
     private var scoreText: String {
@@ -214,7 +219,7 @@ private struct PracticeAreaHighlightsCard: View {
             }
         }
         .insightCard()
-        .shadow(color: .black.opacity(0.08), radius: 10)
+        .shadow(color: .black.opacity(0.04), radius: 3, y: 2)
     }
 
     private func attentionSummary(for metric: PracticeAreaMetric) -> String {
@@ -322,7 +327,7 @@ private struct PracticeAreaMetricCard: View {
                 .foregroundStyle(Color("SecondaryText"))
         }
         .insightCard()
-        .shadow(color: .black.opacity(0.08), radius: 10)
+        .shadow(color: .black.opacity(0.04), radius: 3, y: 2)
     }
 
     private var subtitle: String {
@@ -399,7 +404,7 @@ private struct PracticeAreaInsightsEmptyState: View {
             .tint(Color("AccentColor"))
         }
         .insightCard()
-        .shadow(color: .black.opacity(0.08), radius: 10)
+        .shadow(color: .black.opacity(0.04), radius: 3, y: 2)
     }
 }
 


### PR DESCRIPTION
- Precomputed activeMetrics, ratedMetrics, attentionMetrics, and improvingMetrics in PracticeAreaInsightsContent.init.
- Converted attentionScore / sorting helpers to static.
- Replaced the nested “Practice Areas” LazyVStack with VStack.
- Replaced LazyVStack with VStack in PracticeAreaInsightDetailView.
- Reduced heavy card shadows