### PR TITLE
Improve navigation destination performance

### DIFF
--- a/RiyaazPal/Views/Insights/ConcertPracticeAreaInsightsContent.swift
+++ b/RiyaazPal/Views/Insights/ConcertPracticeAreaInsightsContent.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 
+private struct ConcertPracticeAreaInsightRoute: Hashable {
+    let metricID: String
+}
+
 struct ConcertPracticeAreaInsightsContent: View {
     let metrics: [PracticeAreaMetric]
     let activePracticeAreaCount: Int
@@ -87,17 +91,20 @@ struct ConcertPracticeAreaInsightsContent: View {
                         .foregroundStyle(Color("PrimaryText"))
 
                     ForEach(metrics) { metric in
-                        NavigationLink {
-                            PracticeAreaInsightDetailView(
-                                metric: metric,
-                                mode: .concert
-                            )
-                        } label: {
+                        NavigationLink(value: ConcertPracticeAreaInsightRoute(metricID: metric.id)) {
                             ConcertPracticeAreaMetricCard(metric: metric)
                         }
                         .buttonStyle(.plain)
                     }
                 }
+            }
+        }
+        .navigationDestination(for: ConcertPracticeAreaInsightRoute.self) { route in
+            if let metric = metrics.first(where: { $0.id == route.metricID }) {
+                PracticeAreaInsightDetailView(
+                    metric: metric,
+                    mode: .concert
+                )
             }
         }
     }

--- a/RiyaazPal/Views/Insights/PracticeAreaInsightsContent.swift
+++ b/RiyaazPal/Views/Insights/PracticeAreaInsightsContent.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 
+private struct PracticeAreaInsightRoute: Hashable {
+    let metricID: String
+}
+
 struct PracticeAreaInsightsContent: View {
     let metrics: [PracticeAreaMetric]
     let activePracticeAreaCount: Int
@@ -80,17 +84,20 @@ struct PracticeAreaInsightsContent: View {
                         .foregroundStyle(Color("PrimaryText"))
 
                     ForEach(metrics) { metric in
-                        NavigationLink {
-                            PracticeAreaInsightDetailView(
-                                metric: metric,
-                                mode: .practice
-                            )
-                        } label: {
+                        NavigationLink(value: PracticeAreaInsightRoute(metricID: metric.id)) {
                             PracticeAreaMetricCard(metric: metric)
                         }
                         .buttonStyle(.plain)
                     }
                 }
+            }
+        }
+        .navigationDestination(for: PracticeAreaInsightRoute.self) { route in
+            if let metric = metrics.first(where: { $0.id == route.metricID }) {
+                PracticeAreaInsightDetailView(
+                    metric: metric,
+                    mode: .practice
+                )
             }
         }
     }

--- a/RiyaazPal/Views/Profile/ProfileView.swift
+++ b/RiyaazPal/Views/Profile/ProfileView.swift
@@ -10,6 +10,11 @@ import Foundation
 import SwiftUI
 import SwiftData
 
+private enum ProfileRoute: Hashable {
+    case practiceAreas
+    case practiceNudges
+}
+
 struct ProfileView: View {
 
     @Query(sort: \PracticeAreaEntity.order)
@@ -27,9 +32,7 @@ struct ProfileView: View {
                 
                 // MARK: Practice Areas Section
                 Section {
-                    NavigationLink {
-                        PracticeAreasPanel()
-                    } label: {
+                    NavigationLink(value: ProfileRoute.practiceAreas) {
                         PracticeAreasRow(areas: practiceAreas)
                     }
                 } header: {
@@ -40,9 +43,7 @@ struct ProfileView: View {
 
                 // MARK: Practice Nudges Section
                 Section {
-                    NavigationLink {
-                        PracticeNudgeSettingsView()
-                    } label: {
+                    NavigationLink(value: ProfileRoute.practiceNudges) {
                         PracticeNudgesRow()
                     }
                 } header: {
@@ -66,6 +67,14 @@ struct ProfileView: View {
                 #endif
             }
             .listStyle(.insetGrouped)
+            .navigationDestination(for: ProfileRoute.self) { route in
+                switch route {
+                case .practiceAreas:
+                    PracticeAreasPanel()
+                case .practiceNudges:
+                    PracticeNudgeSettingsView()
+                }
+            }
         }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
- This PR uses `.navigationDestination` for navigation links to avoid eagerly building destinations.