### PR TITLE
feature/Add local debug test data seeder

### DIFF
--- a/RiyaazPal.xcodeproj/project.pbxproj
+++ b/RiyaazPal.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		C0FFBDE42F366DED00F84DFA /* SessionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFBDE32F366DED00F84DFA /* SessionType.swift */; };
 		C0FFBDE62F36722200F84DFA /* SessionTypePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFBDE52F36722200F84DFA /* SessionTypePicker.swift */; };
 		C0FFBDE82F3675D000F84DFA /* SessionTypeChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFBDE72F3675D000F84DFA /* SessionTypeChip.swift */; };
+		C0DE00112FDB000000000001 /* TestDataSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00102FDB000000000001 /* TestDataSeeder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -131,6 +132,7 @@
 		C0FFBDE32F366DED00F84DFA /* SessionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionType.swift; sourceTree = "<group>"; };
 		C0FFBDE52F36722200F84DFA /* SessionTypePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTypePicker.swift; sourceTree = "<group>"; };
 		C0FFBDE72F3675D000F84DFA /* SessionTypeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTypeChip.swift; sourceTree = "<group>"; };
+		C0DE00102FDB000000000001 /* TestDataSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataSeeder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,6 +202,7 @@
 				C066A2B32F18E07E005A5D44 /* Info.plist */,
 				C055C0022F50000000D00C01 /* RiyaazPal.entitlements */,
 				C066A28B2F0F38D2005A5D44 /* Analytics */,
+				C0DE00122FDB000000000001 /* Debug */,
 				C0A430CD2F05991100C2401C /* Views */,
 				C0A430CC2F05990B00C2401C /* ViewModels */,
 				C0A430CB2F05990000C2401C /* Models */,
@@ -340,6 +343,14 @@
 			path = CategoryDetail;
 			sourceTree = "<group>";
 		};
+		C0DE00122FDB000000000001 /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				C0DE00102FDB000000000001 /* TestDataSeeder.swift */,
+			);
+			path = Debug;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -469,6 +480,7 @@
 				C0A430BD2F03494200C2401C /* RiyaazPalApp.swift in Sources */,
 				C0E580502F1DD1EB00571C5E /* SessionActionButton.swift in Sources */,
 				C0FFBDE42F366DED00F84DFA /* SessionType.swift in Sources */,
+				C0DE00112FDB000000000001 /* TestDataSeeder.swift in Sources */,
 				C066A2A22F14F641005A5D44 /* DateTimePickerSheet.swift in Sources */,
 				C060F7002F4EEC23008946CA /* TagSuggester.swift in Sources */,
 				C091E6372F425D1200271B6E /* PracticeTimelineTypeEmptyState.swift in Sources */,

--- a/RiyaazPal/Analytics/PracticeAreaMetrics.swift
+++ b/RiyaazPal/Analytics/PracticeAreaMetrics.swift
@@ -89,6 +89,30 @@ struct PracticeAreaPerformanceTransfer {
     let status: PracticeAreaPerformanceTransferStatus
 }
 
+struct PracticeAreaMetricAreaInput: Sendable {
+    let id: UUID
+    let name: String
+    let isActive: Bool
+    let order: Int
+}
+
+struct PracticeAreaMetricRatingInput: Sendable {
+    let sessionID: UUID
+    let practiceAreaID: UUID
+    let areaName: String
+    let didPractice: Bool
+    let score: Int?
+    let createdAt: Date
+    let lastModified: Date
+}
+
+struct PracticeAreaMetricSessionInput: Sendable {
+    let id: UUID
+    let startTime: Date
+    let sessionType: SessionType
+    let lastModified: Date
+}
+
 enum PracticeAreaTrendDirection: Equatable {
     case improving
     case declining
@@ -120,6 +144,46 @@ enum PracticeAreaMetricsCalculator {
         now: Date = Date(),
         calendar: Calendar = .current
     ) -> [PracticeAreaMetric] {
+        compute(
+            practiceAreas: practiceAreas.map {
+                PracticeAreaMetricAreaInput(
+                    id: $0.id,
+                    name: $0.name,
+                    isActive: $0.isActive,
+                    order: $0.order
+                )
+            },
+            ratings: ratings.map {
+                PracticeAreaMetricRatingInput(
+                    sessionID: $0.sessionID,
+                    practiceAreaID: $0.practiceAreaID,
+                    areaName: $0.areaName,
+                    didPractice: $0.didPractice,
+                    score: $0.score,
+                    createdAt: $0.createdAt,
+                    lastModified: $0.lastModified
+                )
+            },
+            sessions: sessions.map {
+                PracticeAreaMetricSessionInput(
+                    id: $0.id,
+                    startTime: $0.startTime,
+                    sessionType: $0.resolvedSessionType,
+                    lastModified: $0.lastModified
+                )
+            },
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    static func compute(
+        practiceAreas: [PracticeAreaMetricAreaInput],
+        ratings: [PracticeAreaMetricRatingInput],
+        sessions: [PracticeAreaMetricSessionInput],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [PracticeAreaMetric] {
 
         let sessionByID = Dictionary(
             sessions.map { ($0.id, $0) },
@@ -138,7 +202,7 @@ enum PracticeAreaMetricsCalculator {
                 areaName: rating.areaName,
                 normalizedAreaName: normalizeAreaName(rating.areaName),
                 sessionID: session.id,
-                sessionType: session.resolvedSessionType,
+                sessionType: session.sessionType,
                 date: session.startTime,
                 score: PracticeAreaRatingEntity.clampedScore(score),
                 lastModified: rating.lastModified
@@ -212,7 +276,7 @@ private extension PracticeAreaMetricsCalculator {
 
     static func buildMetric(
         normalizedAreaName: String,
-        activeArea: PracticeAreaEntity?,
+        activeArea: PracticeAreaMetricAreaInput?,
         entries: [ScoredPracticeAreaEntry],
         now: Date,
         calendar: Calendar

--- a/RiyaazPal/Analytics/PracticeSuggestionRecommender.swift
+++ b/RiyaazPal/Analytics/PracticeSuggestionRecommender.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PracticeSuggestionRecommendation: Equatable {
+struct PracticeSuggestionRecommendation: Equatable, Sendable {
     let areaID: UUID?
     let areaName: String
     let priorityScore: Double
@@ -15,7 +15,7 @@ struct PracticeSuggestionRecommendation: Equatable {
     let supportingReasons: [PracticeSuggestionReason]
 }
 
-enum PracticeSuggestionReason: Equatable {
+enum PracticeSuggestionReason: Equatable, Sendable {
     case noRatingsYet
     case neglected(days: Int?)
     case dueForPractice(days: Int)

--- a/RiyaazPal/Debug/TestDataSeeder.swift
+++ b/RiyaazPal/Debug/TestDataSeeder.swift
@@ -1,0 +1,339 @@
+#if DEBUG
+import Foundation
+import SwiftData
+
+enum TestDataSeedScenario: String, CaseIterable, Identifiable {
+    case freshUser
+    case inconsistentImproving
+    case powerUser
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .freshUser:
+            return "Fresh User"
+        case .inconsistentImproving:
+            return "Inconsistent Improving User"
+        case .powerUser:
+            return "Power User"
+        }
+    }
+}
+
+enum TestDataSeeder {
+
+    enum SeedError: LocalizedError {
+        case iCloudSyncEnabled
+
+        var errorDescription: String? {
+            switch self {
+            case .iCloudSyncEnabled:
+                return "Turn off iCloud sync and restart RiyaazPal before seeding local test data."
+            }
+        }
+    }
+
+    static func seed(
+        _ scenario: TestDataSeedScenario,
+        context: ModelContext,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) throws {
+        guard UserDefaults.standard.object(forKey: RiyaazPalModelContainer.iCloudSyncEnabledKey) as? Bool == false else {
+            throw SeedError.iCloudSyncEnabled
+        }
+
+        try clear(context: context)
+        try context.save()
+
+        switch scenario {
+        case .freshUser:
+            break
+        case .inconsistentImproving:
+            seedInconsistentImprovingUser(context: context, now: now, calendar: calendar)
+        case .powerUser:
+            seedPowerUser(context: context, now: now, calendar: calendar)
+        }
+
+        try context.save()
+    }
+}
+
+private extension TestDataSeeder {
+
+    static func clear(context: ModelContext) throws {
+        let ratings = try context.fetch(FetchDescriptor<PracticeAreaRatingEntity>())
+        let sessions = try context.fetch(FetchDescriptor<PracticeSession>())
+        let practiceAreas = try context.fetch(FetchDescriptor<PracticeAreaEntity>())
+
+        for rating in ratings {
+            context.delete(rating)
+        }
+
+        for session in sessions {
+            context.delete(session)
+        }
+
+        for area in practiceAreas {
+            context.delete(area)
+        }
+    }
+
+    static func seedInconsistentImprovingUser(
+        context: ModelContext,
+        now: Date,
+        calendar: Calendar
+    ) {
+        let areas = insertAreas(
+            ["Alaap", "Sapat Taans", "Layakari", "Bol Taans"],
+            context: context,
+            now: now,
+            calendar: calendar
+        )
+
+        let sparsePracticeDays = [-27, -22, -16, -10, -6, -2]
+
+        for (index, dayOffset) in sparsePracticeDays.enumerated() {
+            let score = min(8, 4 + index)
+            insertSession(
+                dayOffset: dayOffset,
+                durationMinutes: 42,
+                notes: "Seeded practice",
+                sessionType: .practice,
+                context: context,
+                areas: areas,
+                scores: [
+                    "Alaap": score,
+                    "Sapat Taans": max(5, score - 1),
+                    "Layakari": index.isMultiple(of: 2) ? 6 : 7
+                ],
+                now: now,
+                calendar: calendar
+            )
+        }
+    }
+
+    static func seedPowerUser(
+        context: ModelContext,
+        now: Date,
+        calendar: Calendar
+    ) {
+        let areas = insertAreas(
+            ["Alaap", "Sapat Taans", "Layakari", "Bol Taans", "Meend"],
+            context: context,
+            now: now,
+            calendar: calendar
+        )
+
+        for index in 0..<1000 {
+            let dayOffset = -360 + (index / 3)
+            let sessionType: SessionType = index.isMultiple(of: 13) ? .concert : .practice
+            let scores = baselineScores(for: index, sessionType: sessionType)
+
+            insertSession(
+                dayOffset: dayOffset,
+                durationMinutes: sessionType == .concert ? 90 : 55,
+                notes: sessionType == .concert ? "Seeded concert" : "Seeded practice",
+                sessionType: sessionType,
+                context: context,
+                areas: areas,
+                scores: scores,
+                now: now,
+                calendar: calendar
+            )
+        }
+
+        seedPowerUserSignals(
+            context: context,
+            areas: areas,
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    static func seedPowerUserSignals(
+        context: ModelContext,
+        areas: [String: PracticeAreaEntity],
+        now: Date,
+        calendar: Calendar
+    ) {
+        let previousWindowDays = [-13, -12, -11, -10, -9, -8]
+        let recentWindowDays = [-6, -5, -4, -3, -2, -1]
+
+        for dayOffset in previousWindowDays {
+            insertSession(
+                dayOffset: dayOffset,
+                durationMinutes: 60,
+                notes: "Seeded previous trend window",
+                sessionType: .practice,
+                context: context,
+                areas: areas,
+                scores: [
+                    "Alaap": 5,
+                    "Sapat Taans": 8,
+                    "Layakari": 7,
+                    "Bol Taans": 8
+                ],
+                now: now,
+                calendar: calendar
+            )
+        }
+
+        for dayOffset in recentWindowDays {
+            insertSession(
+                dayOffset: dayOffset,
+                durationMinutes: 60,
+                notes: "Seeded recent trend window",
+                sessionType: .practice,
+                context: context,
+                areas: areas,
+                scores: [
+                    "Alaap": 8,
+                    "Sapat Taans": 5,
+                    "Layakari": 7,
+                    "Bol Taans": 9
+                ],
+                now: now,
+                calendar: calendar
+            )
+        }
+
+        for dayOffset in [-6, -4, -2] {
+            insertSession(
+                dayOffset: dayOffset,
+                durationMinutes: 85,
+                notes: "Seeded concert drop",
+                sessionType: .concert,
+                context: context,
+                areas: areas,
+                scores: [
+                    "Alaap": 7,
+                    "Sapat Taans": 6,
+                    "Layakari": 7,
+                    "Bol Taans": 5
+                ],
+                now: now,
+                calendar: calendar
+            )
+        }
+
+        insertSession(
+            dayOffset: -14,
+            durationMinutes: 45,
+            notes: "Seeded neglected area",
+            sessionType: .practice,
+            context: context,
+            areas: areas,
+            scores: [
+                "Meend": 6
+            ],
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    static func insertAreas(
+        _ names: [String],
+        context: ModelContext,
+        now: Date,
+        calendar: Calendar
+    ) -> [String: PracticeAreaEntity] {
+        var areas: [String: PracticeAreaEntity] = [:]
+
+        for (index, name) in names.enumerated() {
+            let area = PracticeAreaEntity(
+                name: name,
+                createdAt: calendar.date(byAdding: .day, value: -120, to: now) ?? now,
+                isActive: true,
+                order: index
+            )
+
+            context.insert(area)
+            areas[name] = area
+        }
+
+        return areas
+    }
+
+    static func insertSession(
+        dayOffset: Int,
+        durationMinutes: Int,
+        notes: String,
+        sessionType: SessionType,
+        context: ModelContext,
+        areas: [String: PracticeAreaEntity],
+        scores: [String: Int],
+        now: Date,
+        calendar: Calendar
+    ) {
+        let startTime = sessionDate(dayOffset: dayOffset, now: now, calendar: calendar)
+        let session = PracticeSession(
+            startTime: startTime,
+            duration: TimeInterval(durationMinutes * 60),
+            notes: notes,
+            tags: [],
+            detailedNotes: "",
+            lastModified: startTime,
+            sessionType: sessionType,
+            confidence: sessionType == .concert ? 6 : 5
+        )
+
+        context.insert(session)
+
+        for (name, score) in scores {
+            guard let area = areas[name] else { continue }
+
+            let rating = PracticeAreaRatingEntity(
+                sessionID: session.id,
+                practiceAreaID: area.id,
+                areaName: area.name,
+                didPractice: true,
+                score: score,
+                createdAt: startTime,
+                lastModified: startTime
+            )
+
+            context.insert(rating)
+        }
+    }
+
+    static func baselineScores(
+        for index: Int,
+        sessionType: SessionType
+    ) -> [String: Int] {
+        let variation = index % 3
+
+        if sessionType == .concert {
+            return [
+                "Alaap": 7,
+                "Sapat Taans": 6 + variation,
+                "Layakari": 7,
+                "Bol Taans": 5
+            ]
+        }
+
+        return [
+            "Alaap": 6 + variation,
+            "Sapat Taans": 7,
+            "Layakari": 7,
+            "Bol Taans": 8
+        ]
+    }
+
+    static func sessionDate(
+        dayOffset: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> Date {
+        let day = calendar.date(byAdding: .day, value: dayOffset, to: now) ?? now
+        let hour = 9 + abs(dayOffset % 8)
+        return calendar.date(
+            bySettingHour: hour,
+            minute: 0,
+            second: 0,
+            of: day
+        ) ?? day
+    }
+}
+#endif

--- a/RiyaazPal/Models/SessionType.swift
+++ b/RiyaazPal/Models/SessionType.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-enum SessionType: String, Codable, CaseIterable {
+enum SessionType: String, Codable, CaseIterable, Sendable {
     case practice
     case concert
 }
-

--- a/RiyaazPal/RiyaazPalApp.swift
+++ b/RiyaazPal/RiyaazPalApp.swift
@@ -69,6 +69,10 @@ final class RiyaazPalAppDelegate: NSObject, UIApplicationDelegate, UNUserNotific
 
 struct RootTabView: View {
     @EnvironmentObject var router: TabRouter
+
+    @AppStorage("practiceNudgesEnabled")
+    private var practiceNudgesEnabled = false
+
     var body: some View {
         TabView(selection: $router.selectedTab) {
             NavigationStack {
@@ -90,7 +94,11 @@ struct RootTabView: View {
         .onReceive(NotificationCenter.default.publisher(for: .practiceNudgeNotificationTapped)) { _ in
             router.selectedTab = .timeline
         }
-        .background(PracticeNudgeRefreshTask())
+        .background {
+            if practiceNudgesEnabled {
+                PracticeNudgeRefreshTask()
+            }
+        }
     }
 }
 

--- a/RiyaazPal/ViewModels/EditSessionViewModel.swift
+++ b/RiyaazPal/ViewModels/EditSessionViewModel.swift
@@ -207,6 +207,29 @@ extension EditSessionViewModel {
         return didChange
     }
 
+    func makeSaveRequest() -> EditSessionSaveRequest {
+        EditSessionSaveRequest(
+            sessionID: draft.id,
+            startTime: draft.startTime,
+            duration: draft.duration,
+            notes: draft.notes,
+            tags: draft.tags,
+            detailedNotes: draft.detailedNotes,
+            sessionType: draft.sessionType,
+            confidence: draft.confidence,
+            hasPracticeAreaReflection: hasPracticeAreaReflection,
+            ratings: practiceAreaDrafts.map {
+                PracticeAreaRatingSaveRequest(
+                    sessionID: $0.sessionID,
+                    practiceAreaID: $0.practiceAreaID,
+                    areaName: $0.areaName,
+                    didPractice: $0.didPractice,
+                    score: $0.score
+                )
+            }
+        )
+    }
+
     private func normalizeTag(_ tag: String) -> String {
         tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
@@ -451,5 +474,189 @@ struct PracticeAreaQuestionnaireDraft: Identifiable, Hashable {
 
     var resolvedScore: Int {
         score ?? 5
+    }
+}
+
+struct EditSessionSaveRequest: Sendable {
+    let sessionID: UUID
+    let startTime: Date
+    let duration: TimeInterval
+    let notes: String
+    let tags: [String]
+    let detailedNotes: String
+    let sessionType: SessionType
+    let confidence: Int?
+    let hasPracticeAreaReflection: Bool
+    let ratings: [PracticeAreaRatingSaveRequest]
+}
+
+struct PracticeAreaRatingSaveRequest: Sendable {
+    let sessionID: UUID
+    let practiceAreaID: UUID
+    let areaName: String
+    let didPractice: Bool
+    let score: Int?
+}
+
+enum EditSessionBackgroundSaver {
+    static func save(
+        _ request: EditSessionSaveRequest,
+        modelContainer: ModelContainer
+    ) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let context = ModelContext(modelContainer)
+            let sessionID = request.sessionID
+
+            let sessionDescriptor = FetchDescriptor<PracticeSession>(
+                predicate: #Predicate { session in
+                    session.id == sessionID
+                }
+            )
+
+            guard let session = try context.fetch(sessionDescriptor).first else {
+                return
+            }
+
+            let didUpdateSession = updateSession(session, with: request)
+            let didUpdateRatings = try updateRatings(
+                request.ratings,
+                hasPracticeAreaReflection: request.hasPracticeAreaReflection,
+                sessionID: sessionID,
+                context: context
+            )
+
+            if didUpdateSession || didUpdateRatings {
+                try context.save()
+            }
+        }.value
+    }
+}
+
+private extension EditSessionBackgroundSaver {
+    static func updateSession(
+        _ session: PracticeSession,
+        with request: EditSessionSaveRequest
+    ) -> Bool {
+        var didChange = false
+
+        if session.notes != request.notes {
+            session.notes = request.notes
+            didChange = true
+        }
+
+        if session.tags != request.tags {
+            session.tags = request.tags
+            didChange = true
+        }
+
+        if session.detailedNotes != request.detailedNotes {
+            session.detailedNotes = request.detailedNotes
+            didChange = true
+        }
+
+        if session.duration != request.duration {
+            session.duration = request.duration
+            didChange = true
+        }
+
+        if session.startTime != request.startTime {
+            session.startTime = request.startTime
+            didChange = true
+        }
+
+        if session.resolvedSessionType != request.sessionType {
+            session.sessionType = request.sessionType
+            didChange = true
+        }
+
+        if session.confidence != request.confidence {
+            session.confidence = request.confidence
+            didChange = true
+        }
+
+        if didChange {
+            session.lastModified = .now
+        }
+
+        return didChange
+    }
+
+    static func updateRatings(
+        _ ratingRequests: [PracticeAreaRatingSaveRequest],
+        hasPracticeAreaReflection: Bool,
+        sessionID: UUID,
+        context: ModelContext
+    ) throws -> Bool {
+        guard hasPracticeAreaReflection else { return false }
+
+        var didChange = false
+        let now = Date.now
+        let descriptor = FetchDescriptor<PracticeAreaRatingEntity>(
+            predicate: #Predicate { rating in
+                rating.sessionID == sessionID
+            }
+        )
+        let existingRatings = try context.fetch(descriptor)
+
+        let ratingsByAreaID = Dictionary(
+            existingRatings.map { ($0.practiceAreaID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        let ratingsByAreaName = Dictionary(
+            existingRatings.map { (EditSessionViewModel.normalizedAreaName($0.areaName), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        for ratingRequest in ratingRequests {
+            let existingRating = ratingsByAreaID[ratingRequest.practiceAreaID]
+                ?? ratingsByAreaName[EditSessionViewModel.normalizedAreaName(ratingRequest.areaName)]
+
+            if let rating = existingRating {
+                let score = ratingRequest.didPractice
+                    ? ratingRequest.score.map(PracticeAreaRatingEntity.clampedScore)
+                    : nil
+                var didUpdateRating = false
+
+                if rating.practiceAreaID != ratingRequest.practiceAreaID {
+                    rating.practiceAreaID = ratingRequest.practiceAreaID
+                    didUpdateRating = true
+                }
+
+                if rating.areaName != ratingRequest.areaName {
+                    rating.areaName = ratingRequest.areaName
+                    didUpdateRating = true
+                }
+
+                if rating.didPractice != ratingRequest.didPractice {
+                    rating.didPractice = ratingRequest.didPractice
+                    didUpdateRating = true
+                }
+
+                if rating.score != score {
+                    rating.score = score
+                    didUpdateRating = true
+                }
+
+                if didUpdateRating {
+                    rating.lastModified = now
+                    didChange = true
+                }
+            } else {
+                let rating = PracticeAreaRatingEntity(
+                    sessionID: ratingRequest.sessionID,
+                    practiceAreaID: ratingRequest.practiceAreaID,
+                    areaName: ratingRequest.areaName,
+                    didPractice: ratingRequest.didPractice,
+                    score: ratingRequest.score,
+                    createdAt: now,
+                    lastModified: now
+                )
+                context.insert(rating)
+                didChange = true
+            }
+        }
+
+        return didChange
     }
 }

--- a/RiyaazPal/ViewModels/EditSessionViewModel.swift
+++ b/RiyaazPal/ViewModels/EditSessionViewModel.swift
@@ -95,22 +95,59 @@ extension EditSessionViewModel {
         newTag = ""
     }
 
-    func commit() {
-        session.notes = draft.notes
-        session.tags = draft.tags
-        session.detailedNotes = draft.detailedNotes
-        session.duration = draft.duration
-        session.startTime = draft.startTime
-        session.lastModified = .now
-        session.sessionType = draft.sessionType
-        session.confidence = draft.confidence
+    func commit() -> Bool {
+        var didChange = false
+
+        if session.notes != draft.notes {
+            session.notes = draft.notes
+            didChange = true
+        }
+
+        if session.tags != draft.tags {
+            session.tags = draft.tags
+            didChange = true
+        }
+
+        if session.detailedNotes != draft.detailedNotes {
+            session.detailedNotes = draft.detailedNotes
+            didChange = true
+        }
+
+        if session.duration != draft.duration {
+            session.duration = draft.duration
+            didChange = true
+        }
+
+        if session.startTime != draft.startTime {
+            session.startTime = draft.startTime
+            didChange = true
+        }
+
+        if session.resolvedSessionType != draft.sessionType {
+            session.sessionType = draft.sessionType
+            didChange = true
+        }
+
+        if session.confidence != draft.confidence {
+            session.confidence = draft.confidence
+            didChange = true
+        }
+
+        if didChange {
+            session.lastModified = .now
+        }
+
+        return didChange
     }
 
     func commitPracticeAreaRatings(
         context: ModelContext,
         existingRatings: [PracticeAreaRatingEntity]
-    ) {
-        guard hasPracticeAreaReflection else { return }
+    ) -> Bool {
+        guard hasPracticeAreaReflection else { return false }
+
+        var didChange = false
+        let now = Date.now
 
         let ratingsByAreaID = Dictionary(
             existingRatings.map { ($0.practiceAreaID, $0) },
@@ -127,11 +164,33 @@ extension EditSessionViewModel {
                 ?? ratingsByAreaName[Self.normalizedAreaName(draft.areaName)]
 
             if let rating = existingRating {
-                rating.practiceAreaID = draft.practiceAreaID
-                rating.areaName = draft.areaName
-                rating.didPractice = draft.didPractice
-                rating.score = draft.didPractice ? draft.score.map(PracticeAreaRatingEntity.clampedScore) : nil
-                rating.lastModified = .now
+                let score = draft.didPractice ? draft.score.map(PracticeAreaRatingEntity.clampedScore) : nil
+                var didUpdateRating = false
+
+                if rating.practiceAreaID != draft.practiceAreaID {
+                    rating.practiceAreaID = draft.practiceAreaID
+                    didUpdateRating = true
+                }
+
+                if rating.areaName != draft.areaName {
+                    rating.areaName = draft.areaName
+                    didUpdateRating = true
+                }
+
+                if rating.didPractice != draft.didPractice {
+                    rating.didPractice = draft.didPractice
+                    didUpdateRating = true
+                }
+
+                if rating.score != score {
+                    rating.score = score
+                    didUpdateRating = true
+                }
+
+                if didUpdateRating {
+                    rating.lastModified = now
+                    didChange = true
+                }
             } else {
                 let rating = PracticeAreaRatingEntity(
                     sessionID: draft.sessionID,
@@ -141,8 +200,11 @@ extension EditSessionViewModel {
                     score: draft.score
                 )
                 context.insert(rating)
+                didChange = true
             }
         }
+
+        return didChange
     }
 
     private func normalizeTag(_ tag: String) -> String {

--- a/RiyaazPal/ViewModels/EditSessionViewModel.swift
+++ b/RiyaazPal/ViewModels/EditSessionViewModel.swift
@@ -246,7 +246,7 @@ extension EditSessionViewModel {
 
     func computeSuggestions() {
         suggestedTags = Self.suggester.suggestions(
-            title: draft.notes,
+            title: "",
             details: draft.detailedNotes,
             existingTags: draft.tags,
             sessions: tagSuggestionSessions,
@@ -274,7 +274,6 @@ extension EditSessionViewModel {
 
     func updateNotes(_ text: String) {
         draft.notes = text
-        suggestionTrigger.send()
     }
 
     func updateDetailedNotes(_ text: String) {

--- a/RiyaazPal/ViewModels/InsightsViewModel.swift
+++ b/RiyaazPal/ViewModels/InsightsViewModel.swift
@@ -12,10 +12,82 @@ import Combine
 final class InsightsViewModel: ObservableObject {
     
     @Published var currentWindow: DateRange = InsightWindowHelper.dateRange()
+    @Published private(set) var practiceAreaMetrics: [PracticeAreaMetric] = []
+    @Published private(set) var activePracticeAreaCount = 0
+    @Published private(set) var concertCount = 0
+    @Published private(set) var isLoadingMetrics = false
     @Published private(set) var summaryText: String?
 
+    private var loadedMetricsRequestID: String?
+    private var metricsTask: Task<Void, Never>?
     private var loadedSummaryRequestID: String?
     private var loadingSummaryRequestID: String?
+
+    deinit {
+        metricsTask?.cancel()
+    }
+
+    func loadMetrics(
+        practiceAreas: [PracticeAreaEntity],
+        ratings: [PracticeAreaRatingEntity],
+        sessions: [PracticeSession],
+        window: DateRange,
+        requestID: String
+    ) {
+        guard loadedMetricsRequestID != requestID else { return }
+
+        metricsTask?.cancel()
+        isLoadingMetrics = true
+
+        let practiceAreaInputs = practiceAreas.map {
+            PracticeAreaMetricAreaInput(
+                id: $0.id,
+                name: $0.name,
+                isActive: $0.isActive,
+                order: $0.order
+            )
+        }
+        let ratingInputs = ratings.map {
+            PracticeAreaMetricRatingInput(
+                sessionID: $0.sessionID,
+                practiceAreaID: $0.practiceAreaID,
+                areaName: $0.areaName,
+                didPractice: $0.didPractice,
+                score: $0.score,
+                createdAt: $0.createdAt,
+                lastModified: $0.lastModified
+            )
+        }
+        let sessionInputs = sessions.map {
+            PracticeAreaMetricSessionInput(
+                id: $0.id,
+                startTime: $0.startTime,
+                sessionType: $0.resolvedSessionType,
+                lastModified: $0.lastModified
+            )
+        }
+        let activeAreaCount = practiceAreaInputs.filter(\.isActive).count
+        let concertSessionCount = sessionInputs.filter { $0.sessionType == .concert }.count
+
+        metricsTask = Task.detached(priority: .userInitiated) {
+            let metrics = PracticeAreaMetricsCalculator.compute(
+                practiceAreas: practiceAreaInputs,
+                ratings: ratingInputs,
+                sessions: sessionInputs,
+                now: window.end
+            )
+
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                self.practiceAreaMetrics = metrics
+                self.activePracticeAreaCount = activeAreaCount
+                self.concertCount = concertSessionCount
+                self.loadedMetricsRequestID = requestID
+                self.isLoadingMetrics = false
+            }
+        }
+    }
 
     func loadMetricSummary(
         metrics: [PracticeAreaMetric],

--- a/RiyaazPal/ViewModels/InsightsViewModel.swift
+++ b/RiyaazPal/ViewModels/InsightsViewModel.swift
@@ -16,6 +16,7 @@ final class InsightsViewModel: ObservableObject {
     @Published private(set) var activePracticeAreaCount = 0
     @Published private(set) var concertCount = 0
     @Published private(set) var isLoadingMetrics = false
+    @Published private(set) var hasLoadedMetrics = false
     @Published private(set) var summaryText: String?
 
     private var loadedMetricsRequestID: String?
@@ -85,6 +86,7 @@ final class InsightsViewModel: ObservableObject {
                 self.concertCount = concertSessionCount
                 self.loadedMetricsRequestID = requestID
                 self.isLoadingMetrics = false
+                self.hasLoadedMetrics = true
             }
         }
     }

--- a/RiyaazPal/Views/Insights/InsightsView.swift
+++ b/RiyaazPal/Views/Insights/InsightsView.swift
@@ -46,7 +46,9 @@ struct InsightsView: View {
                     insightsGuidanceCard
                     insightsModeChips
                     insightSummaryCard
-                    if mode == .practice {
+                    if !insightsViewModel.hasLoadedMetrics {
+                        insightsLoadingCard
+                    } else if mode == .practice {
                         practiceInsightsContent
                     } else {
                         concertInsightsContent
@@ -151,6 +153,26 @@ private extension InsightsView {
             .insightCard()
             .shadow(color: .black.opacity(0.08), radius: 10)
         }
+    }
+
+    var insightsLoadingCard: some View {
+        HStack(spacing: 12) {
+            ProgressView()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Loading insights")
+                    .font(.headline)
+                    .foregroundStyle(Color("PrimaryText"))
+
+                Text("Preparing your practice-area trends.")
+                    .font(.subheadline)
+                    .foregroundStyle(Color("SecondaryText"))
+            }
+
+            Spacer()
+        }
+        .insightCard()
+        .shadow(color: .black.opacity(0.04), radius: 3, y: 2)
     }
 
     var practiceInsightsContent: some View {

--- a/RiyaazPal/Views/Insights/InsightsView.swift
+++ b/RiyaazPal/Views/Insights/InsightsView.swift
@@ -34,19 +34,6 @@ struct InsightsView: View {
 
     @AppStorage(FirstRunGuidanceKeys.insightsTip)
     private var hasSeenInsightsTip = false
-    
-    private var concertCount: Int {
-        sessions.filter { $0.resolvedSessionType == .concert }.count
-    }
-
-    private var practiceAreaMetrics: [PracticeAreaMetric] {
-        PracticeAreaMetricsCalculator.compute(
-            practiceAreas: practiceAreas,
-            ratings: practiceAreaRatings,
-            sessions: sessions,
-            now: insightsViewModel.currentWindow.end
-        )
-    }
 
     var body: some View {
         ZStack {
@@ -90,11 +77,20 @@ struct InsightsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .practiceNudgeNotificationTapped)) { _ in
             showProfile = false
         }
+        .task(id: metricsRefreshID) {
+            insightsViewModel.loadMetrics(
+                practiceAreas: practiceAreas,
+                ratings: practiceAreaRatings,
+                sessions: sessions,
+                window: insightsViewModel.currentWindow,
+                requestID: metricsRefreshID
+            )
+        }
         .task(id: summaryRefreshID) {
             await insightsViewModel.loadMetricSummary(
-                metrics: practiceAreaMetrics,
-                activePracticeAreaCount: practiceAreas.filter(\.isActive).count,
-                concertCount: concertCount,
+                metrics: insightsViewModel.practiceAreaMetrics,
+                activePracticeAreaCount: insightsViewModel.activePracticeAreaCount,
+                concertCount: insightsViewModel.concertCount,
                 window: insightsViewModel.currentWindow,
                 requestID: summaryRefreshID
             )
@@ -159,8 +155,8 @@ private extension InsightsView {
 
     var practiceInsightsContent: some View {
         PracticeAreaInsightsContent(
-            metrics: practiceAreaMetrics,
-            activePracticeAreaCount: practiceAreas.filter(\.isActive).count,
+            metrics: insightsViewModel.practiceAreaMetrics,
+            activePracticeAreaCount: insightsViewModel.activePracticeAreaCount,
             onManagePracticeAreas: {
                 showProfile = true
             }
@@ -169,9 +165,9 @@ private extension InsightsView {
     
     var concertInsightsContent: some View {
         ConcertPracticeAreaInsightsContent(
-            metrics: practiceAreaMetrics,
-            activePracticeAreaCount: practiceAreas.filter(\.isActive).count,
-            concertCount: concertCount,
+            metrics: insightsViewModel.practiceAreaMetrics,
+            activePracticeAreaCount: insightsViewModel.activePracticeAreaCount,
+            concertCount: insightsViewModel.concertCount,
             onManagePracticeAreas: {
                 showProfile = true
             }
@@ -227,8 +223,30 @@ private extension InsightsView {
         return formatter.string(from: insightsViewModel.currentWindow.start, to: insightsViewModel.currentWindow.end)
     }
 
+    private var metricsRefreshID: String {
+        let latestSessionModified = sessions.map(\.lastModified).max()?.timeIntervalSince1970 ?? 0
+        let latestRatingModified = practiceAreaRatings.map(\.lastModified).max()?.timeIntervalSince1970 ?? 0
+        let practiceAreaValues = practiceAreas.map { area in
+            [
+                area.id.uuidString,
+                area.name,
+                "\(area.isActive)",
+                "\(area.order)"
+            ].joined(separator: ":")
+        }.joined(separator: "|")
+
+        return [
+            "\(insightsViewModel.currentWindow.end.timeIntervalSince1970)",
+            "\(sessions.count)",
+            "\(latestSessionModified)",
+            "\(practiceAreaRatings.count)",
+            "\(latestRatingModified)",
+            practiceAreaValues
+        ].joined(separator: "#")
+    }
+
     private var summaryRefreshID: String {
-        let metricValues = practiceAreaMetrics.map { metric in
+        let metricValues = insightsViewModel.practiceAreaMetrics.map { metric in
             [
                 metric.id,
                 metric.areaName,
@@ -256,8 +274,8 @@ private extension InsightsView {
         return [
             "\(insightsViewModel.currentWindow.start.timeIntervalSince1970)",
             "\(insightsViewModel.currentWindow.end.timeIntervalSince1970)",
-            "\(practiceAreas.filter(\.isActive).count)",
-            "\(concertCount)",
+            "\(insightsViewModel.activePracticeAreaCount)",
+            "\(insightsViewModel.concertCount)",
             metricValues
         ].joined(separator: "#")
     }

--- a/RiyaazPal/Views/Profile/ProfileView.swift
+++ b/RiyaazPal/Views/Profile/ProfileView.swift
@@ -37,6 +37,11 @@ struct ProfileView: View {
 
     @State private var showICloudRestartNote = false
     @State private var showDeleteSessionsConfirmation = false
+    #if DEBUG
+    @State private var seedAlertTitle = ""
+    @State private var seedAlertMessage = ""
+    @State private var showSeedAlert = false
+    #endif
 
     var body: some View {
         ZStack {
@@ -112,10 +117,18 @@ struct ProfileView: View {
                     } label: {
                         Label("Reset First-Run Tips", systemImage: "arrow.counterclockwise")
                     }
+
+                    ForEach(TestDataSeedScenario.allCases) { scenario in
+                        Button {
+                            seedTestData(scenario)
+                        } label: {
+                            Label("Seed \(scenario.title)", systemImage: "square.stack.3d.up")
+                        }
+                    }
                 } header: {
                     Text("Developer")
                 } footer: {
-                    Text("Replay timeline, reflection, and insights guidance without clearing app data.")
+                    Text("Replay guidance or seed local-only test data. Seeding is blocked unless iCloud sync is off and the app has been restarted.")
                 }
                 #endif
             }
@@ -145,6 +158,14 @@ struct ProfileView: View {
         } message: {
             Text("This permanently deletes all practice and concert sessions and their reflection scores. If iCloud sync is on, the deletion may sync across your devices.")
         }
+        #if DEBUG
+        .alert(seedAlertTitle, isPresented: $showSeedAlert) {
+            Button("OK", role: .cancel) {
+            }
+        } message: {
+            Text(seedAlertMessage)
+        }
+        #endif
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text("Profile")
@@ -180,6 +201,21 @@ struct ProfileView: View {
 
         try? context.save()
     }
+
+    #if DEBUG
+    private func seedTestData(_ scenario: TestDataSeedScenario) {
+        do {
+            try TestDataSeeder.seed(scenario, context: context)
+            seedAlertTitle = "Seeded \(scenario.title)"
+            seedAlertMessage = "Local test data is ready. iCloud sync stayed off."
+        } catch {
+            seedAlertTitle = "Could Not Seed Data"
+            seedAlertMessage = error.localizedDescription
+        }
+
+        showSeedAlert = true
+    }
+    #endif
 }
 
 private struct PracticeAreasRow: View {

--- a/RiyaazPal/Views/Profile/ProfileView.swift
+++ b/RiyaazPal/Views/Profile/ProfileView.swift
@@ -19,12 +19,6 @@ struct ProfileView: View {
 
     @Query(sort: \PracticeAreaEntity.order)
     private var practiceAreas: [PracticeAreaEntity]
-
-    @Query(sort: \PracticeSession.startTime, order: .reverse)
-    private var sessions: [PracticeSession]
-
-    @Query(sort: \PracticeAreaRatingEntity.createdAt)
-    private var practiceAreaRatings: [PracticeAreaRatingEntity]
     
     @Environment(\.dismiss)
     private var dismiss
@@ -103,7 +97,6 @@ struct ProfileView: View {
                     } label: {
                         Label("Delete All Sessions", systemImage: "trash")
                     }
-                    .disabled(sessions.isEmpty)
                 } header: {
                     Text("Data")
                 } footer: {
@@ -191,15 +184,22 @@ struct ProfileView: View {
     }
 
     private func deleteAllSessions() {
-        for rating in practiceAreaRatings {
-            context.delete(rating)
-        }
+        do {
+            let ratings = try context.fetch(FetchDescriptor<PracticeAreaRatingEntity>())
+            let sessions = try context.fetch(FetchDescriptor<PracticeSession>())
 
-        for session in sessions {
-            context.delete(session)
-        }
+            for rating in ratings {
+                context.delete(rating)
+            }
 
-        try? context.save()
+            for session in sessions {
+                context.delete(session)
+            }
+
+            try context.save()
+        } catch {
+            assertionFailure("Failed to delete sessions: \(error)")
+        }
     }
 
     #if DEBUG

--- a/RiyaazPal/Views/Session/EditSessionView.swift
+++ b/RiyaazPal/Views/Session/EditSessionView.swift
@@ -237,12 +237,14 @@ private extension EditSessionView {
     var saveAndCancelButtons: some View {
         VStack(spacing: 12) {
             Button {
-                editSessionViewModel.commit()
-                editSessionViewModel.commitPracticeAreaRatings(
+                let didUpdateSession = editSessionViewModel.commit()
+                let didUpdateRatings = editSessionViewModel.commitPracticeAreaRatings(
                     context: context,
                     existingRatings: sessionPracticeAreaRatings
                 )
-                try? context.save()
+                if didUpdateSession || didUpdateRatings {
+                    try? context.save()
+                }
                 dismiss()
             } label: {
                 Text("Save Changes")

--- a/RiyaazPal/Views/Session/EditSessionView.swift
+++ b/RiyaazPal/Views/Session/EditSessionView.swift
@@ -121,6 +121,7 @@ struct EditSessionView: View {
                             .shadow(.drop(radius: 1, y: -1))
                     )
             }
+            .ignoresSafeArea(.keyboard, edges: .bottom)
             .onAppear {
                 practiceAreasViewModel.attachContext(context)
                 if sessionTitle.isEmpty {

--- a/RiyaazPal/Views/Session/EditSessionView.swift
+++ b/RiyaazPal/Views/Session/EditSessionView.swift
@@ -26,6 +26,7 @@ struct EditSessionView: View {
     @State private var showPracticeAreaQuestionnaire = false
     @State private var sessionPracticeAreaRatings: [PracticeAreaRatingEntity] = []
     @State private var previousReflectionRatings: [PracticeAreaRatingEntity] = []
+    @State private var sessionTitle: String = ""
 
     @AppStorage(FirstRunGuidanceKeys.reflectionTip)
     private var hasSeenReflectionTip = false
@@ -49,10 +50,7 @@ struct EditSessionView: View {
                         VStack(spacing: 8) {
                             TextField(
                                 "Practice Session",
-                                text: Binding(
-                                    get: { editSessionViewModel.draft.notes },
-                                    set: { editSessionViewModel.updateNotes($0) }
-                                )
+                                text: $sessionTitle
                             )
                             .font(.title2)
                             .fontWeight(.semibold)
@@ -60,6 +58,9 @@ struct EditSessionView: View {
                             .multilineTextAlignment(.center)
                             .lineLimit(1)
                             .submitLabel(.done)
+                            .onSubmit {
+                                editSessionViewModel.updateNotes(sessionTitle)
+                            }
 
                             Divider()
                         }
@@ -122,6 +123,9 @@ struct EditSessionView: View {
             }
             .onAppear {
                 practiceAreasViewModel.attachContext(context)
+                if sessionTitle.isEmpty {
+                    sessionTitle = editSessionViewModel.draft.notes
+                }
                 editSessionViewModel.configureTagSource(sessions: sessions)
                 let currentRatings = fetchSessionPracticeAreaRatings()
                 sessionPracticeAreaRatings = currentRatings
@@ -256,6 +260,7 @@ private extension EditSessionView {
     var saveAndCancelButtons: some View {
         VStack(spacing: 12) {
             Button {
+                editSessionViewModel.updateNotes(sessionTitle)
                 let saveRequest = editSessionViewModel.makeSaveRequest()
                 Task {
                     do {

--- a/RiyaazPal/Views/Session/EditSessionView.swift
+++ b/RiyaazPal/Views/Session/EditSessionView.swift
@@ -256,13 +256,16 @@ private extension EditSessionView {
     var saveAndCancelButtons: some View {
         VStack(spacing: 12) {
             Button {
-                let didUpdateSession = editSessionViewModel.commit()
-                let didUpdateRatings = editSessionViewModel.commitPracticeAreaRatings(
-                    context: context,
-                    existingRatings: sessionPracticeAreaRatings
-                )
-                if didUpdateSession || didUpdateRatings {
-                    try? context.save()
+                let saveRequest = editSessionViewModel.makeSaveRequest()
+                Task {
+                    do {
+                        try await EditSessionBackgroundSaver.save(
+                            saveRequest,
+                            modelContainer: RiyaazPalModelContainer.shared
+                        )
+                    } catch {
+                        assertionFailure("Failed to save session: \(error)")
+                    }
                 }
                 dismiss()
             } label: {

--- a/RiyaazPal/Views/Session/EditSessionView.swift
+++ b/RiyaazPal/Views/Session/EditSessionView.swift
@@ -23,10 +23,9 @@ struct EditSessionView: View {
     @Query(sort: \PracticeAreaEntity.order)
     private var practiceAreas: [PracticeAreaEntity]
 
-    @Query(sort: \PracticeAreaRatingEntity.createdAt)
-    private var practiceAreaRatings: [PracticeAreaRatingEntity]
-
     @State private var showPracticeAreaQuestionnaire = false
+    @State private var sessionPracticeAreaRatings: [PracticeAreaRatingEntity] = []
+    @State private var previousReflectionRatings: [PracticeAreaRatingEntity] = []
 
     @AppStorage(FirstRunGuidanceKeys.reflectionTip)
     private var hasSeenReflectionTip = false
@@ -124,9 +123,12 @@ struct EditSessionView: View {
             .onAppear {
                 practiceAreasViewModel.attachContext(context)
                 editSessionViewModel.configureTagSource(sessions: sessions)
+                let currentRatings = fetchSessionPracticeAreaRatings()
+                sessionPracticeAreaRatings = currentRatings
+                previousReflectionRatings = fetchPreviousReflectionRatings()
                 editSessionViewModel.configurePracticeAreaQuestionnaire(
                     practiceAreas: practiceAreas,
-                    existingRatings: sessionPracticeAreaRatings
+                    existingRatings: currentRatings
                 )
             }
             .background(Color("AppBackground"))
@@ -166,11 +168,19 @@ struct EditSessionView: View {
 }
 
 private extension EditSessionView {
-    var sessionPracticeAreaRatings: [PracticeAreaRatingEntity] {
-        practiceAreaRatings.filter { $0.sessionID == session.id }
+    func fetchSessionPracticeAreaRatings() -> [PracticeAreaRatingEntity] {
+        let sessionID = session.id
+        let descriptor = FetchDescriptor<PracticeAreaRatingEntity>(
+            predicate: #Predicate { rating in
+                rating.sessionID == sessionID
+            },
+            sortBy: [SortDescriptor(\.createdAt)]
+        )
+
+        return (try? context.fetch(descriptor)) ?? []
     }
 
-    var previousReflectionRatings: [PracticeAreaRatingEntity] {
+    func fetchPreviousReflectionRatings() -> [PracticeAreaRatingEntity] {
         let candidateSessions = sessions
             .filter {
                 $0.id != session.id &&
@@ -180,7 +190,15 @@ private extension EditSessionView {
             .sorted { $0.startTime > $1.startTime }
 
         for candidateSession in candidateSessions {
-            let ratings = practiceAreaRatings.filter { $0.sessionID == candidateSession.id }
+            let candidateSessionID = candidateSession.id
+            let descriptor = FetchDescriptor<PracticeAreaRatingEntity>(
+                predicate: #Predicate { rating in
+                    rating.sessionID == candidateSessionID
+                },
+                sortBy: [SortDescriptor(\.createdAt)]
+            )
+            let ratings = (try? context.fetch(descriptor)) ?? []
+
             if !ratings.isEmpty {
                 return ratings
             }
@@ -202,6 +220,7 @@ private extension EditSessionView {
     }
 
     func repeatPreviousReflection() {
+        previousReflectionRatings = fetchPreviousReflectionRatings()
         editSessionViewModel.repeatPracticeAreaReflection(
             from: previousReflectionRatings
         )
@@ -271,6 +290,7 @@ private extension EditSessionView {
     var reflectOnSessionButton: some View {
         Button {
             hasSeenReflectionTip = true
+            previousReflectionRatings = fetchPreviousReflectionRatings()
             showPracticeAreaQuestionnaire = true
         } label: {
             HStack(spacing: 12) {

--- a/RiyaazPal/Views/Timeline/PracticeTimelineView.swift
+++ b/RiyaazPal/Views/Timeline/PracticeTimelineView.swift
@@ -193,8 +193,16 @@ private extension PracticeTimelineView {
     }
     
     var timelineList: some View {
+        timelineList(
+            groups: timelineViewModel.groupedByDay(
+                from: timelineFilterViewModel.filteredSessions(from: sessions)
+            )
+        )
+    }
+
+    func timelineList(groups: [(date: Date, sessions: [PracticeSession])]) -> some View {
         List {
-            ForEach(timelineViewModel.groupedByDay(from: timelineFilterViewModel.filteredSessions(from: sessions)), id: \.date) { group in
+            ForEach(groups, id: \.date) { group in
                 Section {
                     ForEach(group.sessions) { session in
                         SessionCard(session: session)
@@ -289,6 +297,9 @@ private extension PracticeTimelineView {
     
     var timelineWithMonthStepper: some View {
         ScrollViewReader { proxy in
+            let filteredSessions = timelineFilterViewModel.filteredSessions(from: sessions)
+            let groupedSessions = timelineViewModel.groupedByDay(from: filteredSessions)
+
             VStack(spacing: 0) {
                 MonthStepper(
                     month: selectedMonth,
@@ -311,8 +322,8 @@ private extension PracticeTimelineView {
 
                 postLogInsightsGuidanceCard
                 
-                if (!timelineFilterViewModel.filteredSessions(from: sessions).isEmpty) {
-                    timelineList
+                if (!filteredSessions.isEmpty) {
+                    timelineList(groups: groupedSessions)
                 } else {
                     PracticeTimelineTypeEmptyState(filter: timelineFilterViewModel.sessionTypeFilter)
                 }
@@ -381,36 +392,29 @@ private extension PracticeTimelineView {
         }
     }
 
-    var practiceAreaMetrics: [PracticeAreaMetric] {
-        PracticeAreaMetricsCalculator.compute(
-            practiceAreas: practiceAreas,
-            ratings: practiceAreaRatings,
-            sessions: sessions
-        )
-    }
-
-    var rankedPracticeRecommendations: [PracticeSuggestionRecommendation] {
-        PracticeSuggestionRecommender.rankedRecommendations(
-            from: practiceAreaMetrics
-        )
-    }
-
     var recommendationRefreshID: String {
-        rankedPracticeRecommendations
-            .prefix(PracticeRecommendationService.defaultShortlistLimit)
-            .map { recommendation in
+        let latestSessionModified = sessions.map(\.lastModified).max()?.timeIntervalSince1970 ?? 0
+        let latestRatingModified = practiceAreaRatings.map(\.lastModified).max()?.timeIntervalSince1970 ?? 0
+        let practiceAreaValues = practiceAreas.map { area in
                 [
-                    recommendation.areaID?.uuidString ?? recommendation.areaName,
-                    recommendation.areaName,
-                    recommendation.priorityScore.formatted(),
-                    "\(recommendation.primaryReason)"
+                    area.id.uuidString,
+                    area.name,
+                    "\(area.isActive)",
+                    "\(area.order)"
                 ].joined(separator: ":")
-            }
-            .joined(separator: "|")
+        }.joined(separator: "|")
+
+        return [
+            "\(sessions.count)",
+            "\(latestSessionModified)",
+            "\(practiceAreaRatings.count)",
+            "\(latestRatingModified)",
+            practiceAreaValues
+        ].joined(separator: "#")
     }
 
     func loadPracticeRecommendation() async {
-        let recommendations = rankedPracticeRecommendations
+        let recommendations = await rankedPracticeRecommendations()
 
         guard let fallbackRecommendation = recommendations.first else {
             practiceRecommendation = nil
@@ -454,6 +458,45 @@ private extension PracticeTimelineView {
         }
 
         isPracticeRecommendationLoading = false
+    }
+
+    func rankedPracticeRecommendations() async -> [PracticeSuggestionRecommendation] {
+        let practiceAreaInputs = practiceAreas.map {
+            PracticeAreaMetricAreaInput(
+                id: $0.id,
+                name: $0.name,
+                isActive: $0.isActive,
+                order: $0.order
+            )
+        }
+        let ratingInputs = practiceAreaRatings.map {
+            PracticeAreaMetricRatingInput(
+                sessionID: $0.sessionID,
+                practiceAreaID: $0.practiceAreaID,
+                areaName: $0.areaName,
+                didPractice: $0.didPractice,
+                score: $0.score,
+                createdAt: $0.createdAt,
+                lastModified: $0.lastModified
+            )
+        }
+        let sessionInputs = sessions.map {
+            PracticeAreaMetricSessionInput(
+                id: $0.id,
+                startTime: $0.startTime,
+                sessionType: $0.resolvedSessionType,
+                lastModified: $0.lastModified
+            )
+        }
+
+        return await Task.detached(priority: .utility) {
+            let metrics = PracticeAreaMetricsCalculator.compute(
+                practiceAreas: practiceAreaInputs,
+                ratings: ratingInputs,
+                sessions: sessionInputs
+            )
+            return PracticeSuggestionRecommender.rankedRecommendations(from: metrics)
+        }.value
     }
 
     func dismissPresentedTimelinePanels() {

--- a/RiyaazPal/Views/Timeline/SessionCard.swift
+++ b/RiyaazPal/Views/Timeline/SessionCard.swift
@@ -26,7 +26,6 @@ struct SessionCard: View {
                 .fill(Color(.secondarySystemGroupedBackground))
         )
         .shadow(color: .black.opacity(0.05), radius: 4, y: 2)
-        .transition(.move(edge: .bottom).combined(with: .opacity))
     }
 }
 


### PR DESCRIPTION
This PR adds a local debug test data seeder with 3 presets (fresh, inconsistent and power user). This will be removed before release. Several performance issues have been identified and some fixed in this PR:
1. Navigation stutter when going from another view to timeline -FIXED - fixed by running recomendation and expensive work off main thread
2. Laggy Save button in edit session - FIXED - Removed ratings observer trigger from edit sessions - fetched on demand 
3. Added loading state in insights view:
4. Compute insights metrics off main thread 
5. Reduced Timeline recomputation during updates, especially recommendation metric work.