### PR TITLE
Feature/timeline scoped swiftdata query

### DIFF
--- a/RiyaazPal.xcodeproj/project.pbxproj
+++ b/RiyaazPal.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		C0A430DB2F059A0600C2401C /* DaySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430DA2F059A0600C2401C /* DaySection.swift */; };
 		C0A430DD2F059CB600C2401C /* SessionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430DC2F059CB600C2401C /* SessionCard.swift */; };
 		C0A430DF2F060DD300C2401C /* PracticeTimelineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430DE2F060DD300C2401C /* PracticeTimelineViewModel.swift */; };
+		C0A430E12FEA000000C2401C /* ICloudSyncStatusMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430E02FEA000000C2401C /* ICloudSyncStatusMonitor.swift */; };
 		C0A430E32F083A2700C2401C /* EditSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430E22F083A2700C2401C /* EditSessionView.swift */; };
 		C0A430E82F08A25C00C2401C /* TagChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430E72F08A25C00C2401C /* TagChip.swift */; };
 		C0A430EA2F08A9CC00C2401C /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430E92F08A9CC00C2401C /* FlowLayout.swift */; };
@@ -112,6 +113,7 @@
 		C0A430DA2F059A0600C2401C /* DaySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaySection.swift; sourceTree = "<group>"; };
 		C0A430DC2F059CB600C2401C /* SessionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCard.swift; sourceTree = "<group>"; };
 		C0A430DE2F060DD300C2401C /* PracticeTimelineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimelineViewModel.swift; sourceTree = "<group>"; };
+		C0A430E02FEA000000C2401C /* ICloudSyncStatusMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSyncStatusMonitor.swift; sourceTree = "<group>"; };
 		C0A430E22F083A2700C2401C /* EditSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSessionView.swift; sourceTree = "<group>"; };
 		C0A430E72F08A25C00C2401C /* TagChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagChip.swift; sourceTree = "<group>"; };
 		C0A430E92F08A9CC00C2401C /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 			children = (
 				C0A430D42F0599CD00C2401C /* PracticeSessionViewModel.swift */,
 				C0A430DE2F060DD300C2401C /* PracticeTimelineViewModel.swift */,
+				C0A430E02FEA000000C2401C /* ICloudSyncStatusMonitor.swift */,
 				C066A2AF2F18893E005A5D44 /* InsightsViewModel.swift */,
 				C0E580412F19EDD400571C5E /* TimelineFilterViewModel.swift */,
 				C0E5804B2F1B00FF00571C5E /* EditSessionViewModel.swift */,
@@ -442,6 +445,7 @@
 				C0D82F172F249F4200B4E0E8 /* Preferences.swift in Sources */,
 				C0A430DB2F059A0600C2401C /* DaySection.swift in Sources */,
 				C0E580442F1A40C700571C5E /* PracticeTimelineEmptyState.swift in Sources */,
+				C0A430E12FEA000000C2401C /* ICloudSyncStatusMonitor.swift in Sources */,
 				C066A2B02F18893E005A5D44 /* InsightsViewModel.swift in Sources */,
 				C0742B9B2F44566A004E7697 /* GoalModel.swift in Sources */,
 				C0864B132F9F3000006E5F6A /* PracticeAreasViewModel.swift in Sources */,

--- a/RiyaazPal/RiyaazPalApp.swift
+++ b/RiyaazPal/RiyaazPalApp.swift
@@ -72,11 +72,13 @@ struct RootTabView: View {
 
     @StateObject private var iCloudSyncStatusMonitor = ICloudSyncStatusMonitor()
 
+    @State private var hasDismissedICloudSyncStatus = false
+
     @AppStorage("practiceNudgesEnabled")
     private var practiceNudgesEnabled = false
 
     var body: some View {
-        ZStack(alignment: .top) {
+        ZStack(alignment: .topTrailing) {
             TabView(selection: $router.selectedTab) {
                 NavigationStack {
                     PracticeTimelineView()
@@ -110,21 +112,38 @@ struct RootTabView: View {
 
     @ViewBuilder
     private var iCloudSyncStatusBanner: some View {
-        if iCloudSyncStatusMonitor.isSyncing {
-            HStack(spacing: 8) {
+        if iCloudSyncStatusMonitor.isSyncing && !hasDismissedICloudSyncStatus {
+            HStack(spacing: 6) {
                 ProgressView()
-                    .controlSize(.small)
+                    .controlSize(.mini)
 
-                Text("Syncing from iCloud")
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(Color("PrimaryText"))
+                Text("Syncing iCloud")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(Color("SecondaryText"))
+
+                Button {
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
+                        hasDismissedICloudSyncStatus = true
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(Color("SecondaryText"))
+                        .frame(width: 18, height: 18)
+                }
+                .buttonStyle(.plain)
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(Color("CardBackground"))
+            .padding(.leading, 10)
+            .padding(.trailing, 6)
+            .padding(.vertical, 7)
+            .background(Color("CardBackground").opacity(0.9))
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .shadow(color: .black.opacity(0.08), radius: 8, y: 3)
-            .padding(.top, 10)
+            .overlay {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color("SecondaryText").opacity(0.12), lineWidth: 1)
+            }
+            .padding(.top, 8)
+            .padding(.trailing, 12)
             .transition(.move(edge: .top).combined(with: .opacity))
             .animation(.spring(response: 0.28, dampingFraction: 0.9), value: iCloudSyncStatusMonitor.isSyncing)
         }

--- a/RiyaazPal/RiyaazPalApp.swift
+++ b/RiyaazPal/RiyaazPalApp.swift
@@ -70,34 +70,62 @@ final class RiyaazPalAppDelegate: NSObject, UIApplicationDelegate, UNUserNotific
 struct RootTabView: View {
     @EnvironmentObject var router: TabRouter
 
+    @StateObject private var iCloudSyncStatusMonitor = ICloudSyncStatusMonitor()
+
     @AppStorage("practiceNudgesEnabled")
     private var practiceNudgesEnabled = false
 
     var body: some View {
-        TabView(selection: $router.selectedTab) {
-            NavigationStack {
-                PracticeTimelineView()
+        ZStack(alignment: .top) {
+            TabView(selection: $router.selectedTab) {
+                NavigationStack {
+                    PracticeTimelineView()
+                }
+                .tabItem {
+                    Label("Timeline", systemImage: "music.note.list")
+                }
+                .tag(TabRouter.Tab.timeline)
+                
+                NavigationStack {
+                    InsightsView()
+                }
+                .tabItem {
+                    Label("Insights", systemImage: "chart.bar")
+                }
+                .tag(TabRouter.Tab.insights)
             }
-            .tabItem {
-                Label("Timeline", systemImage: "music.note.list")
+            .onReceive(NotificationCenter.default.publisher(for: .practiceNudgeNotificationTapped)) { _ in
+                router.selectedTab = .timeline
             }
-            .tag(TabRouter.Tab.timeline)
-            
-            NavigationStack {
-                InsightsView()
+            .background {
+                if practiceNudgesEnabled {
+                    PracticeNudgeRefreshTask()
+                }
             }
-            .tabItem {
-                Label("Insights", systemImage: "chart.bar")
-            }
-            .tag(TabRouter.Tab.insights)
+
+            iCloudSyncStatusBanner
         }
-        .onReceive(NotificationCenter.default.publisher(for: .practiceNudgeNotificationTapped)) { _ in
-            router.selectedTab = .timeline
-        }
-        .background {
-            if practiceNudgesEnabled {
-                PracticeNudgeRefreshTask()
+    }
+
+    @ViewBuilder
+    private var iCloudSyncStatusBanner: some View {
+        if iCloudSyncStatusMonitor.isImporting {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+
+                Text("Syncing from iCloud")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Color("PrimaryText"))
             }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color("CardBackground"))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .shadow(color: .black.opacity(0.08), radius: 8, y: 3)
+            .padding(.top, 10)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .animation(.spring(response: 0.28, dampingFraction: 0.9), value: iCloudSyncStatusMonitor.isImporting)
         }
     }
 }

--- a/RiyaazPal/RiyaazPalApp.swift
+++ b/RiyaazPal/RiyaazPalApp.swift
@@ -80,6 +80,7 @@ struct RootTabView: View {
             TabView(selection: $router.selectedTab) {
                 NavigationStack {
                     PracticeTimelineView()
+                        .environmentObject(iCloudSyncStatusMonitor)
                 }
                 .tabItem {
                     Label("Timeline", systemImage: "music.note.list")
@@ -109,7 +110,7 @@ struct RootTabView: View {
 
     @ViewBuilder
     private var iCloudSyncStatusBanner: some View {
-        if iCloudSyncStatusMonitor.isImporting {
+        if iCloudSyncStatusMonitor.isSyncing {
             HStack(spacing: 8) {
                 ProgressView()
                     .controlSize(.small)
@@ -125,7 +126,7 @@ struct RootTabView: View {
             .shadow(color: .black.opacity(0.08), radius: 8, y: 3)
             .padding(.top, 10)
             .transition(.move(edge: .top).combined(with: .opacity))
-            .animation(.spring(response: 0.28, dampingFraction: 0.9), value: iCloudSyncStatusMonitor.isImporting)
+            .animation(.spring(response: 0.28, dampingFraction: 0.9), value: iCloudSyncStatusMonitor.isSyncing)
         }
     }
 }

--- a/RiyaazPal/RiyaazPalModelContainer.swift
+++ b/RiyaazPal/RiyaazPalModelContainer.swift
@@ -42,7 +42,7 @@ enum RiyaazPalModelContainer {
         }
     }()
 
-    private static var isICloudSyncEnabled: Bool {
+    static var isICloudSyncEnabled: Bool {
         UserDefaults.standard.object(forKey: iCloudSyncEnabledKey) as? Bool ?? true
     }
 

--- a/RiyaazPal/ViewModels/ICloudSyncStatusMonitor.swift
+++ b/RiyaazPal/ViewModels/ICloudSyncStatusMonitor.swift
@@ -10,10 +10,12 @@ import Foundation
 
 @MainActor
 final class ICloudSyncStatusMonitor: ObservableObject {
-    @Published private(set) var isImporting = false
+    @Published private(set) var isSyncing = false
 
     private var activeImportEventIDs: Set<UUID> = []
+    private var isShowingTimelineSyncHint = false
     private var observer: NSObjectProtocol?
+    private var timelineSyncHintTask: Task<Void, Never>?
 
     init(notificationCenter: NotificationCenter = .default) {
         observer = notificationCenter.addObserver(
@@ -29,9 +31,36 @@ final class ICloudSyncStatusMonitor: ObservableObject {
     }
 
     deinit {
+        timelineSyncHintTask?.cancel()
+
         if let observer {
             NotificationCenter.default.removeObserver(observer)
         }
+    }
+
+    func showTimelineSyncHint(duration: Duration = .seconds(12)) {
+        guard RiyaazPalModelContainer.isICloudSyncEnabled else { return }
+
+        isShowingTimelineSyncHint = true
+        updateSyncingState()
+
+        timelineSyncHintTask?.cancel()
+        timelineSyncHintTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: duration)
+            } catch {
+                return
+            }
+
+            await MainActor.run {
+                self?.isShowingTimelineSyncHint = false
+                self?.updateSyncingState()
+            }
+        }
+    }
+
+    func showTimelineDataChangeHint() {
+        showTimelineSyncHint(duration: .seconds(2))
     }
 
     private func handleCloudKitEventNotification(_ notification: Notification) {
@@ -47,6 +76,10 @@ final class ICloudSyncStatusMonitor: ObservableObject {
             activeImportEventIDs.remove(event.identifier)
         }
 
-        isImporting = !activeImportEventIDs.isEmpty
+        updateSyncingState()
+    }
+
+    private func updateSyncingState() {
+        isSyncing = !activeImportEventIDs.isEmpty || isShowingTimelineSyncHint
     }
 }

--- a/RiyaazPal/ViewModels/ICloudSyncStatusMonitor.swift
+++ b/RiyaazPal/ViewModels/ICloudSyncStatusMonitor.swift
@@ -1,0 +1,52 @@
+//
+//  ICloudSyncStatusMonitor.swift
+//  RiyaazPal
+//
+//  Created by OpenAI on 2026-05-19.
+//
+
+import CoreData
+import Foundation
+
+@MainActor
+final class ICloudSyncStatusMonitor: ObservableObject {
+    @Published private(set) var isImporting = false
+
+    private var activeImportEventIDs: Set<UUID> = []
+    private var observer: NSObjectProtocol?
+
+    init(notificationCenter: NotificationCenter = .default) {
+        observer = notificationCenter.addObserver(
+            forName: NSPersistentCloudKitContainer.eventChangedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.handleCloudKitEventNotification(notification)
+            }
+        }
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    private func handleCloudKitEventNotification(_ notification: Notification) {
+        guard
+            let event = notification.userInfo?[NSPersistentCloudKitContainer.eventNotificationUserInfoKey]
+                as? NSPersistentCloudKitContainer.Event,
+            event.type == .import || event.type == .setup
+        else { return }
+
+        if event.endDate == nil {
+            activeImportEventIDs.insert(event.identifier)
+        } else {
+            activeImportEventIDs.remove(event.identifier)
+        }
+
+        isImporting = !activeImportEventIDs.isEmpty
+    }
+}

--- a/RiyaazPal/ViewModels/PracticeTimelineViewModel.swift
+++ b/RiyaazPal/ViewModels/PracticeTimelineViewModel.swift
@@ -6,92 +6,50 @@
 //
 
 import Foundation
-import SwiftData
 import SwiftUI
 
 @MainActor
 final class PracticeTimelineViewModel: ObservableObject {
 
-    @Published private(set) var sessions: [PracticeSession] = []
-    @Published private(set) var isLoadingInitialPage = false
-    @Published private(set) var isLoadingOlderPage = false
-    @Published private(set) var hasMoreOlderSessions = true
+    @Published private(set) var loadedStartDate: Date
 
-    private let pageSize = 80
+    private let calendar: Calendar
+    private let initialWindowDays = 30
+    private var lastOlderWindowTriggerDate: Date?
 
-    func loadInitialPage(context: ModelContext) {
-        guard sessions.isEmpty, !isLoadingInitialPage else { return }
-
-        isLoadingInitialPage = true
-        defer { isLoadingInitialPage = false }
-
-        do {
-            sessions = try fetchPage(context: context)
-            hasMoreOlderSessions = sessions.count == pageSize
-        } catch {
-            sessions = []
-            hasMoreOlderSessions = false
-        }
+    init(calendar: Calendar = .current, now: Date = Date()) {
+        self.calendar = calendar
+        loadedStartDate = calendar.date(
+            byAdding: .day,
+            value: -initialWindowDays,
+            to: now
+        ) ?? now
     }
 
-    func reloadFirstPage(context: ModelContext) {
-        isLoadingInitialPage = true
-        defer { isLoadingInitialPage = false }
-
-        do {
-            sessions = try fetchPage(context: context)
-            hasMoreOlderSessions = sessions.count == pageSize
-        } catch {
-            hasMoreOlderSessions = false
-        }
-    }
-
-    func loadOlderPageIfNeeded(
+    func loadOlderWindowIfNeeded(
         currentGroupDate: Date,
-        groups: [(date: Date, sessions: [PracticeSession])],
-        context: ModelContext
+        groups: [(date: Date, sessions: [PracticeSession])]
     ) {
         guard groups.last?.date == currentGroupDate else { return }
-        loadOlderPage(context: context)
+        guard lastOlderWindowTriggerDate != currentGroupDate else { return }
+        lastOlderWindowTriggerDate = currentGroupDate
+
+        loadOlderWindow()
     }
 
-    func loadOlderPage(context: ModelContext) {
-        guard hasMoreOlderSessions, !isLoadingOlderPage else { return }
-        guard let oldestLoadedDate = sessions.last?.startTime else { return }
-
-        isLoadingOlderPage = true
-        defer { isLoadingOlderPage = false }
-
-        do {
-            let olderSessions = try fetchPage(
-                olderThan: oldestLoadedDate,
-                context: context
-            )
-            appendUniqueSessions(olderSessions)
-            hasMoreOlderSessions = olderSessions.count == pageSize
-        } catch {
-            hasMoreOlderSessions = false
-        }
+    func loadOlderWindow() {
+        let currentStartOfMonth = calendar.startOfMonth(for: loadedStartDate)
+        loadedStartDate = calendar.date(
+            byAdding: .month,
+            value: -1,
+            to: currentStartOfMonth
+        ) ?? loadedStartDate
     }
 
-    func loadUntilMonthExists(
-        _ month: Date,
-        context: ModelContext,
-        calendar: Calendar = .current
-    ) {
-        while hasMoreOlderSessions,
-              !sessions.contains(where: { calendar.isDate($0.startTime, equalTo: month, toGranularity: .month) }) {
-            let countBeforeLoad = sessions.count
-            loadOlderPage(context: context)
-
-            if sessions.count == countBeforeLoad {
-                break
-            }
-        }
-    }
-
-    func removeSession(_ session: PracticeSession) {
-        sessions.removeAll { $0.id == session.id }
+    func loadWindowIncludingMonth(_ month: Date) {
+        let monthStart = calendar.startOfMonth(for: month)
+        guard monthStart < loadedStartDate else { return }
+        loadedStartDate = monthStart
     }
 
     func groupedByDay(
@@ -106,33 +64,11 @@ final class PracticeTimelineViewModel: ObservableObject {
                 .sorted { $0.key > $1.key }
                 .map { (date: $0.key, sessions: $0.value) }
         }
+}
 
-    private func fetchPage(
-        olderThan date: Date? = nil,
-        context: ModelContext
-    ) throws -> [PracticeSession] {
-        var descriptor: FetchDescriptor<PracticeSession>
-
-        if let date {
-            descriptor = FetchDescriptor<PracticeSession>(
-                predicate: #Predicate { session in
-                    session.startTime < date
-                },
-                sortBy: [SortDescriptor(\.startTime, order: .reverse)]
-            )
-        } else {
-            descriptor = FetchDescriptor<PracticeSession>(
-                sortBy: [SortDescriptor(\.startTime, order: .reverse)]
-            )
-        }
-
-        descriptor.fetchLimit = pageSize
-        return try context.fetch(descriptor)
-    }
-
-    private func appendUniqueSessions(_ olderSessions: [PracticeSession]) {
-        let existingIDs = Set(sessions.map(\.id))
-        sessions.append(contentsOf: olderSessions.filter { !existingIDs.contains($0.id) })
-        sessions.sort { $0.startTime > $1.startTime }
+private extension Calendar {
+    func startOfMonth(for date: Date) -> Date {
+        let components = dateComponents([.year, .month], from: date)
+        return self.date(from: components) ?? startOfDay(for: date)
     }
 }

--- a/RiyaazPal/Views/Timeline/PracticeTimelineView.swift
+++ b/RiyaazPal/Views/Timeline/PracticeTimelineView.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 struct PracticeTimelineView: View {
     @EnvironmentObject var router: TabRouter
+    @EnvironmentObject var iCloudSyncStatusMonitor: ICloudSyncStatusMonitor
 
     @Query(sort: \PracticeAreaEntity.order)
         private var practiceAreas: [PracticeAreaEntity]
@@ -119,6 +120,12 @@ struct PracticeTimelineView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: .practiceNudgeNotificationTapped)) { _ in
                 dismissPresentedTimelinePanels()
+            }
+            .onAppear {
+                iCloudSyncStatusMonitor.showTimelineSyncHint()
+            }
+            .onChange(of: sessions.count) {
+                iCloudSyncStatusMonitor.showTimelineDataChangeHint()
             }
             
             
@@ -655,6 +662,7 @@ extension View {
     return NavigationStack {
         PracticeTimelineView()
     }
+    .environmentObject(ICloudSyncStatusMonitor())
     .modelContainer(container)
     .preferredColorScheme(.light)
 }
@@ -694,6 +702,7 @@ extension View {
     return NavigationStack {
         PracticeTimelineView()
     }
+    .environmentObject(ICloudSyncStatusMonitor())
     .modelContainer(container)
     .preferredColorScheme(.dark)
 }

--- a/RiyaazPal/Views/Timeline/PracticeTimelineView.swift
+++ b/RiyaazPal/Views/Timeline/PracticeTimelineView.swift
@@ -41,22 +41,20 @@ struct PracticeTimelineView: View {
     
     @State private var isScrollingProgrammatically = false
 
-    private var sessions: [PracticeSession] {
-        timelineViewModel.sessions
-    }
-
-    private var isShowingTimelineGuidance: Bool {
-        !hasSeenTimelineStartTip || (!hasSeenPostLogInsightsTip && !sessions.isEmpty)
-    }
+    @State private var pendingScrollMonth: Date?
     
     var body: some View {
+        TimelineSessionQueryView(startDate: timelineViewModel.loadedStartDate) { sessions in
+            timelineBody(sessions: sessions)
+        }
+    }
+
+    func timelineBody(sessions: [PracticeSession]) -> some View {
             ZStack {
                 // App-wide background
                 Color("AppBackground")
                     .ignoresSafeArea()
-                if timelineViewModel.isLoadingInitialPage && sessions.isEmpty {
-                    ProgressView()
-                } else if(sessions.isEmpty  && !sessionViewModel.isSessionActive) {
+                if(sessions.isEmpty  && !sessionViewModel.isSessionActive) {
                     VStack(spacing: 16) {
                         timelineStartGuidanceCard
 
@@ -67,7 +65,7 @@ struct PracticeTimelineView: View {
                 } else if timelineFilterViewModel.isSearching && timelineFilterViewModel.filteredSessions(from: sessions).isEmpty {
                     PracticeTimelineFilteredEmptyState()
                 } else {
-                    timelineWithMonthStepper
+                    timelineWithMonthStepper(sessions: sessions)
                         .listStyle(.plain)
                         .scrollContentBackground(.hidden)
                         .scrollTransition(.interactive) { content, phase in
@@ -116,9 +114,6 @@ struct PracticeTimelineView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
             }
-            .task {
-                timelineViewModel.loadInitialPage(context: context)
-            }
             .task(id: recommendationRefreshID) {
                 await loadPracticeRecommendation()
             }
@@ -127,7 +122,28 @@ struct PracticeTimelineView: View {
             }
             
             
-        }
+    }
+}
+
+private struct TimelineSessionQueryView<Content: View>: View {
+    @Query private var sessions: [PracticeSession]
+
+    private let content: ([PracticeSession]) -> Content
+
+    init(startDate: Date, @ViewBuilder content: @escaping ([PracticeSession]) -> Content) {
+        _sessions = Query(
+            filter: #Predicate<PracticeSession> { session in
+                session.startTime >= startDate
+            },
+            sort: \PracticeSession.startTime,
+            order: .reverse
+        )
+        self.content = content
+    }
+
+    var body: some View {
+        content(sessions)
+    }
 }
 
 private extension PracticeTimelineView {
@@ -139,7 +155,6 @@ private extension PracticeTimelineView {
                 context.insert(session)
                 do {
                     try context.save()
-                    timelineViewModel.reloadFirstPage(context: context)
                 } catch {
                     // TODO: alert if failed to save
                     print("Failed to save session: \(error.localizedDescription)")
@@ -196,12 +211,8 @@ private extension PracticeTimelineView {
                    value: sessionViewModel.isSessionActive)
     }
     
-    var timelineList: some View {
-        timelineList(
-            groups: timelineViewModel.groupedByDay(
-                from: timelineFilterViewModel.filteredSessions(from: sessions)
-            )
-        )
+    func isShowingTimelineGuidance(sessions: [PracticeSession]) -> Bool {
+        !hasSeenTimelineStartTip || (!hasSeenPostLogInsightsTip && !sessions.isEmpty)
     }
 
     func timelineList(groups: [(date: Date, sessions: [PracticeSession])]) -> some View {
@@ -218,7 +229,6 @@ private extension PracticeTimelineView {
                             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                                 Button(role: .destructive) {
                                     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                                    timelineViewModel.removeSession(session)
                                     context.delete(session)
                                     do {
                                         try context.save()
@@ -239,24 +249,13 @@ private extension PracticeTimelineView {
                         .foregroundStyle(.secondary)
                         .onAppear {
                             updateMonthOnScroll(to: group.date)
-                            timelineViewModel.loadOlderPageIfNeeded(
+                            timelineViewModel.loadOlderWindowIfNeeded(
                                 currentGroupDate: group.date,
-                                groups: groups,
-                                context: context
+                                groups: groups
                             )
                         }
                 }
                 .id(Calendar.current.startOfDay(for: group.date))
-            }
-
-            if timelineViewModel.isLoadingOlderPage {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
-                }
-                .listRowInsets(.init())
-                .listRowBackground(Color.clear)
             }
         }
     }
@@ -307,7 +306,6 @@ private extension PracticeTimelineView {
 
         do {
             try context.save()
-            timelineViewModel.reloadFirstPage(context: context)
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
             selectedSession = session
         } catch {
@@ -316,7 +314,7 @@ private extension PracticeTimelineView {
     }
 
     
-    var timelineWithMonthStepper: some View {
+    func timelineWithMonthStepper(sessions: [PracticeSession]) -> some View {
         ScrollViewReader { proxy in
             let filteredSessions = timelineFilterViewModel.filteredSessions(from: sessions)
             let groupedSessions = timelineViewModel.groupedByDay(from: filteredSessions)
@@ -325,12 +323,12 @@ private extension PracticeTimelineView {
                 MonthStepper(
                     month: selectedMonth,
                     onPrevious: {
-                        shiftMonth(by: -1, proxy: proxy)
+                        shiftMonth(by: -1, proxy: proxy, sessions: sessions)
                     },
                     onNext: {
-                        shiftMonth(by: 1, proxy: proxy)
+                        shiftMonth(by: 1, proxy: proxy, sessions: sessions)
                     },
-                    hasMoreOlderSessions: timelineViewModel.hasMoreOlderSessions,
+                    hasMoreOlderSessions: true,
                     oldestLoadedSessionDate: sessions.last?.startTime
                 )
                 sessionTypeFilterChips.padding(.top, 8)
@@ -340,9 +338,9 @@ private extension PracticeTimelineView {
                     .padding(.top, 10)
                     .padding(.bottom, 6)
 
-                practiceRecommendationCard
+                practiceRecommendationCard(sessions: sessions)
 
-                postLogInsightsGuidanceCard
+                postLogInsightsGuidanceCard(sessions: sessions)
                 
                 if (!filteredSessions.isEmpty) {
                     timelineList(groups: groupedSessions)
@@ -351,6 +349,12 @@ private extension PracticeTimelineView {
                 }
                 
 
+            }
+            .onChange(of: sessions.count) {
+                scrollToPendingMonth(proxy: proxy, sessions: sessions)
+            }
+            .onChange(of: timelineViewModel.loadedStartDate) {
+                scrollToPendingMonth(proxy: proxy, sessions: sessions)
             }
         }
     }
@@ -371,7 +375,7 @@ private extension PracticeTimelineView {
     }
 
     @ViewBuilder
-    var postLogInsightsGuidanceCard: some View {
+    func postLogInsightsGuidanceCard(sessions: [PracticeSession]) -> some View {
         if !hasSeenPostLogInsightsTip,
            !sessions.isEmpty,
            !timelineFilterViewModel.isSearching {
@@ -394,9 +398,9 @@ private extension PracticeTimelineView {
     }
 
     @ViewBuilder
-    var practiceRecommendationCard: some View {
+    func practiceRecommendationCard(sessions: [PracticeSession]) -> some View {
         if (practiceRecommendation != nil || isPracticeRecommendationLoading),
-           !isShowingTimelineGuidance,
+           !isShowingTimelineGuidance(sessions: sessions),
            dismissedPracticeRecommendationID != recommendationRefreshID,
            !timelineFilterViewModel.isSearching,
            timelineFilterViewModel.sessionTypeFilter != .concert {
@@ -531,7 +535,7 @@ private extension PracticeTimelineView {
         showProfile = false
     }
 
-    func shiftMonth(by delta: Int, proxy: ScrollViewProxy) {
+    func shiftMonth(by delta: Int, proxy: ScrollViewProxy, sessions: [PracticeSession]) {
         guard
             let newMonth = Calendar.current.date(
                 byAdding: .month,
@@ -545,10 +549,11 @@ private extension PracticeTimelineView {
         selectedMonth = newMonth
 
         if delta < 0 {
-            timelineViewModel.loadUntilMonthExists(newMonth, context: context)
+            timelineViewModel.loadWindowIncludingMonth(newMonth)
         }
 
-        scrollToMonth(newMonth, proxy: proxy)
+        pendingScrollMonth = newMonth
+        scrollToPendingMonth(proxy: proxy, sessions: sessions)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             isScrollingProgrammatically = false
         }
@@ -566,7 +571,15 @@ private extension PracticeTimelineView {
             }
         }
     
-    func scrollToMonth(_ month: Date, proxy: ScrollViewProxy) {
+    func scrollToPendingMonth(proxy: ScrollViewProxy, sessions: [PracticeSession]) {
+        guard let pendingScrollMonth else { return }
+
+        if scrollToMonth(pendingScrollMonth, proxy: proxy, sessions: sessions) {
+            self.pendingScrollMonth = nil
+        }
+    }
+
+    func scrollToMonth(_ month: Date, proxy: ScrollViewProxy, sessions: [PracticeSession]) -> Bool {
         let calendar = Calendar.current
 
         guard let targetDate = timelineViewModel
@@ -575,13 +588,15 @@ private extension PracticeTimelineView {
             .first(where: {
                 calendar.isDate($0, equalTo: month, toGranularity: .month)
             })
-        else { return }
+        else { return false }
 
         let scrollID = calendar.startOfDay(for: targetDate)
 
         withAnimation(.spring(response: 0.4, dampingFraction: 0.9)) {
             proxy.scrollTo(scrollID, anchor: .topLeading)
         }
+
+        return true
     }
 }
 


### PR DESCRIPTION
This PR reintroduces swiftdata `Query` for fetching sessions on timeline. The query is scoped to the most recent sessions for performance. This PR fixes the issue of some sessions not loading on fresh install. 

A syncing icloud message was also added for fresh install syncing. 