### PR TITLE
bug/Fix renamed practice area insights

### DIFF
--- a/RiyaazPal/Analytics/PracticeAreaMetrics.swift
+++ b/RiyaazPal/Analytics/PracticeAreaMetrics.swift
@@ -209,25 +209,40 @@ enum PracticeAreaMetricsCalculator {
             )
         })
 
+        let activeAreas = practiceAreas
+            .filter(\.isActive)
+            .sorted { $0.order < $1.order }
+
+        let activeAreasByID = Dictionary(
+            activeAreas.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
         let activeAreasByName = Dictionary(
-            practiceAreas
-                .filter(\.isActive)
-                .sorted { $0.order < $1.order }
-                .map { (normalizeAreaName($0.name), $0) },
+            activeAreas.map { (normalizeAreaName($0.name), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        let activeAreasByMetricKey = Dictionary(
+            activeAreas.map { (metricKey(for: $0.id), $0) },
             uniquingKeysWith: { first, _ in first }
         )
 
         let groupedEntries = Dictionary(grouping: scoredEntries) { entry in
-            entry.normalizedAreaName
+            metricKey(
+                for: entry,
+                activeAreasByID: activeAreasByID,
+                activeAreasByName: activeAreasByName
+            )
         }
 
-        let areaKeys = Set(activeAreasByName.keys).union(groupedEntries.keys)
+        let areaKeys = Set(activeAreasByMetricKey.keys).union(groupedEntries.keys)
 
         return areaKeys
             .map { key in
                 buildMetric(
-                    normalizedAreaName: key,
-                    activeArea: activeAreasByName[key],
+                    metricKey: key,
+                    activeArea: activeAreasByMetricKey[key],
                     entries: groupedEntries[key] ?? [],
                     now: now,
                     calendar: calendar
@@ -264,7 +279,7 @@ private extension PracticeAreaMetricsCalculator {
     ) -> [ScoredPracticeAreaEntry] {
         let entriesByAreaAndSession = Dictionary(
             entries.map { entry in
-                ("\(entry.normalizedAreaName)-\(entry.sessionID.uuidString)", entry)
+                ("\(entry.areaID.uuidString)-\(entry.sessionID.uuidString)", entry)
             },
             uniquingKeysWith: { first, second in
                 first.lastModified >= second.lastModified ? first : second
@@ -275,7 +290,7 @@ private extension PracticeAreaMetricsCalculator {
     }
 
     static func buildMetric(
-        normalizedAreaName: String,
+        metricKey: String,
         activeArea: PracticeAreaMetricAreaInput?,
         entries: [ScoredPracticeAreaEntry],
         now: Date,
@@ -320,10 +335,10 @@ private extension PracticeAreaMetricsCalculator {
         let practiceEntries = sortedEntries.filter { $0.sessionType == .practice }
         let concertEntries = sortedEntries.filter { $0.sessionType == .concert }
 
-        let areaName = activeArea?.name ?? latestEntry?.areaName ?? normalizedAreaName
+        let areaName = activeArea?.name ?? latestEntry?.areaName ?? metricKey
 
         return PracticeAreaMetric(
-            id: normalizedAreaName,
+            id: metricKey,
             areaID: activeArea?.id ?? latestEntry?.areaID,
             areaName: areaName,
             isActive: activeArea != nil,
@@ -482,6 +497,26 @@ private extension PracticeAreaMetricsCalculator {
         calendar: Calendar
     ) -> Date {
         calendar.date(byAdding: .day, value: -days, to: now) ?? now
+    }
+
+    static func metricKey(for areaID: UUID) -> String {
+        "area:\(areaID.uuidString)"
+    }
+
+    static func metricKey(
+        for entry: ScoredPracticeAreaEntry,
+        activeAreasByID: [UUID: PracticeAreaMetricAreaInput],
+        activeAreasByName: [String: PracticeAreaMetricAreaInput]
+    ) -> String {
+        if activeAreasByID[entry.areaID] != nil {
+            return metricKey(for: entry.areaID)
+        }
+
+        if let activeArea = activeAreasByName[entry.normalizedAreaName] {
+            return metricKey(for: activeArea.id)
+        }
+
+        return "archived:\(entry.normalizedAreaName)"
     }
 
     static func normalizeAreaName(_ name: String) -> String {


### PR DESCRIPTION
this PR fixes renaming practice areas - earlier it would register as a new practice area insights card. This PR uses grouping by area id to keep insights stable (e.g renaming alap to alapchari should just rename the insights card already there)
