### PR TITLE
bug/Move insight navigation destinations out of content

### DIFF
--- a/RiyaazPal/Views/Insights/ConcertPracticeAreaInsightsContent.swift
+++ b/RiyaazPal/Views/Insights/ConcertPracticeAreaInsightsContent.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-private struct ConcertPracticeAreaInsightRoute: Hashable {
+struct ConcertPracticeAreaInsightRoute: Hashable {
     let metricID: String
 }
 
@@ -97,14 +97,6 @@ struct ConcertPracticeAreaInsightsContent: View {
                         .buttonStyle(.plain)
                     }
                 }
-            }
-        }
-        .navigationDestination(for: ConcertPracticeAreaInsightRoute.self) { route in
-            if let metric = metrics.first(where: { $0.id == route.metricID }) {
-                PracticeAreaInsightDetailView(
-                    metric: metric,
-                    mode: .concert
-                )
             }
         }
     }

--- a/RiyaazPal/Views/Insights/InsightsView.swift
+++ b/RiyaazPal/Views/Insights/InsightsView.swift
@@ -60,6 +60,22 @@ struct InsightsView: View {
 
         .navigationTitle("Insights")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(for: PracticeAreaInsightRoute.self) { route in
+            if let metric = insightsViewModel.practiceAreaMetrics.first(where: { $0.id == route.metricID }) {
+                PracticeAreaInsightDetailView(
+                    metric: metric,
+                    mode: .practice
+                )
+            }
+        }
+        .navigationDestination(for: ConcertPracticeAreaInsightRoute.self) { route in
+            if let metric = insightsViewModel.practiceAreaMetrics.first(where: { $0.id == route.metricID }) {
+                PracticeAreaInsightDetailView(
+                    metric: metric,
+                    mode: .concert
+                )
+            }
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {

--- a/RiyaazPal/Views/Insights/PracticeAreaInsightsContent.swift
+++ b/RiyaazPal/Views/Insights/PracticeAreaInsightsContent.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-private struct PracticeAreaInsightRoute: Hashable {
+struct PracticeAreaInsightRoute: Hashable {
     let metricID: String
 }
 
@@ -95,14 +95,6 @@ struct PracticeAreaInsightsContent: View {
                         .buttonStyle(.plain)
                     }
                 }
-            }
-        }
-        .navigationDestination(for: PracticeAreaInsightRoute.self) { route in
-            if let metric = metrics.first(where: { $0.id == route.metricID }) {
-                PracticeAreaInsightDetailView(
-                    metric: metric,
-                    mode: .practice
-                )
             }
         }
     }


### PR DESCRIPTION
Fixes this error message:  ```Do not put a navigation destination modifier inside a "lazy” container, like `List` or `LazyVStack`. These containers create child views only when needed to render on screen. Add the navigation destination modifier outside these containers so that the navigation stack can always see the destination. There's a misplaced `navigationDestination(for:destination:)` modifier for type `PracticeAreaInsightRoute`. It will be ignored in a future release.```

Fixed by moving navigation destination modifer outside of the lazy containers