### PR TITLE
fix/Avoid rating queries during onboarding

### DIFF
--- a/RiyaazPal.xcodeproj/project.pbxproj
+++ b/RiyaazPal.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		C0864B232FAE0000006E5F6A /* PracticeRecommendationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B222FAE0000006E5F6A /* PracticeRecommendationService.swift */; };
 		C0864B252FB0000006E5F6A /* PracticeRecommendationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B242FB0000006E5F6A /* PracticeRecommendationCard.swift */; };
 		C0864B272FB1000006E5F6A /* PracticeNudgeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B262FB1000006E5F6A /* PracticeNudgeSettingsView.swift */; };
+		C0864B302FE0000006E5F6A /* PracticeNudgeOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B2F2FE0000006E5F6A /* PracticeNudgeOnboardingView.swift */; };
 		C0864B292FB2000006E5F6A /* PracticeNudgeNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B282FB2000006E5F6A /* PracticeNudgeNotificationService.swift */; };
 		C0864B2B2FB3000006E5F6A /* PracticeNudgeNotificationRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B2A2FB3000006E5F6A /* PracticeNudgeNotificationRouting.swift */; };
 		C0864B2D2FB5000006E5F6A /* PracticeAreaFocusBreakdownCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B2C2FB5000006E5F6A /* PracticeAreaFocusBreakdownCard.swift */; };
@@ -100,6 +101,7 @@
 		C0864B222FAE0000006E5F6A /* PracticeRecommendationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeRecommendationService.swift; sourceTree = "<group>"; };
 		C0864B242FB0000006E5F6A /* PracticeRecommendationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeRecommendationCard.swift; sourceTree = "<group>"; };
 		C0864B262FB1000006E5F6A /* PracticeNudgeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeNudgeSettingsView.swift; sourceTree = "<group>"; };
+		C0864B2F2FE0000006E5F6A /* PracticeNudgeOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeNudgeOnboardingView.swift; sourceTree = "<group>"; };
 		C0864B282FB2000006E5F6A /* PracticeNudgeNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeNudgeNotificationService.swift; sourceTree = "<group>"; };
 		C0864B2A2FB3000006E5F6A /* PracticeNudgeNotificationRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeNudgeNotificationRouting.swift; sourceTree = "<group>"; };
 		C0864B2C2FB5000006E5F6A /* PracticeAreaFocusBreakdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreaFocusBreakdownCard.swift; sourceTree = "<group>"; };
@@ -327,6 +329,7 @@
 				C0D82F162F249F4200B4E0E8 /* Preferences.swift */,
 				C04482E22F273BD700068D74 /* SetupWelcomeView.swift */,
 				C04482E42F273BE500068D74 /* SetupCompleteView.swift */,
+				C0864B2F2FE0000006E5F6A /* PracticeNudgeOnboardingView.swift */,
 			);
 			path = Setup;
 			sourceTree = "<group>";
@@ -466,6 +469,7 @@
 				C0864B232FAE0000006E5F6A /* PracticeRecommendationService.swift in Sources */,
 				C0864B252FB0000006E5F6A /* PracticeRecommendationCard.swift in Sources */,
 				C0864B272FB1000006E5F6A /* PracticeNudgeSettingsView.swift in Sources */,
+				C0864B302FE0000006E5F6A /* PracticeNudgeOnboardingView.swift in Sources */,
 				C0864B2F2FC0000006E5F6A /* ArchivedPracticeAreasView.swift in Sources */,
 				C0864B292FB2000006E5F6A /* PracticeNudgeNotificationService.swift in Sources */,
 				C0864B2B2FB3000006E5F6A /* PracticeNudgeNotificationRouting.swift in Sources */,

--- a/RiyaazPal/RiyaazPalApp.swift
+++ b/RiyaazPal/RiyaazPalApp.swift
@@ -151,14 +151,7 @@ struct RootTabView: View {
 }
 
 private struct PracticeNudgeRefreshTask: View {
-    @Query(sort: \PracticeSession.startTime, order: .reverse)
-    private var sessions: [PracticeSession]
-
-    @Query(sort: \PracticeAreaEntity.order)
-    private var practiceAreas: [PracticeAreaEntity]
-
-    @Query(sort: \PracticeAreaRatingEntity.createdAt)
-    private var practiceAreaRatings: [PracticeAreaRatingEntity]
+    @Environment(\.modelContext) private var modelContext
 
     @AppStorage("practiceNudgesEnabled")
     private var practiceNudgesEnabled = false
@@ -181,29 +174,45 @@ private struct PracticeNudgeRefreshTask: View {
 }
 
 private extension PracticeNudgeRefreshTask {
-    var practiceAreaMetrics: [PracticeAreaMetric] {
-        PracticeAreaMetricsCalculator.compute(
-            practiceAreas: practiceAreas,
-            ratings: practiceAreaRatings,
-            sessions: sessions
-        )
-    }
-
-    var rankedPracticeRecommendations: [PracticeSuggestionRecommendation] {
-        PracticeSuggestionRecommender.rankedRecommendations(
-            from: practiceAreaMetrics
-        )
-    }
-
     func refreshDailyNudgeOnce() async {
         guard !hasRefreshed else { return }
         hasRefreshed = true
 
+        guard practiceNudgesEnabled else { return }
+
         _ = await PracticeNudgeNotificationService.refreshDailyNudgeIfPossible(
             isEnabled: practiceNudgesEnabled,
-            recommendations: rankedPracticeRecommendations,
+            recommendations: rankedPracticeRecommendations(),
             hour: practiceNudgeHour,
             minute: practiceNudgeMinute
+        )
+    }
+
+    func rankedPracticeRecommendations() -> [PracticeSuggestionRecommendation] {
+        let sessions = (try? modelContext.fetch(
+            FetchDescriptor<PracticeSession>(
+                sortBy: [SortDescriptor(\.startTime, order: .reverse)]
+            )
+        )) ?? []
+        let practiceAreas = (try? modelContext.fetch(
+            FetchDescriptor<PracticeAreaEntity>(
+                sortBy: [SortDescriptor(\.order)]
+            )
+        )) ?? []
+        let practiceAreaRatings = (try? modelContext.fetch(
+            FetchDescriptor<PracticeAreaRatingEntity>(
+                sortBy: [SortDescriptor(\.createdAt)]
+            )
+        )) ?? []
+
+        let metrics = PracticeAreaMetricsCalculator.compute(
+            practiceAreas: practiceAreas,
+            ratings: practiceAreaRatings,
+            sessions: sessions
+        )
+
+        return PracticeSuggestionRecommender.rankedRecommendations(
+            from: metrics
         )
     }
 }

--- a/RiyaazPal/Views/Setup/PracticeNudgeOnboardingView.swift
+++ b/RiyaazPal/Views/Setup/PracticeNudgeOnboardingView.swift
@@ -1,0 +1,150 @@
+//
+//  PracticeNudgeOnboardingView.swift
+//  RiyaazPal
+//
+//  Created by Codex on 2026-06-01.
+//
+
+import SwiftUI
+import UserNotifications
+
+struct PracticeNudgeOnboardingView: View {
+
+    @AppStorage("practiceNudgesEnabled")
+    private var practiceNudgesEnabled = false
+
+    @AppStorage("practiceNudgeHour")
+    private var practiceNudgeHour = 9
+
+    @AppStorage("practiceNudgeMinute")
+    private var practiceNudgeMinute = 0
+
+    @State private var authorizationStatus: UNAuthorizationStatus = .notDetermined
+    @State private var isRequestingPermission = false
+
+    var body: some View {
+        List {
+            Section {
+                Toggle(
+                    "Practice nudges",
+                    isOn: Binding(
+                        get: { practiceNudgesEnabled },
+                        set: handleNudgeToggle
+                    )
+                )
+                .disabled(isRequestingPermission)
+
+                DatePicker(
+                    "Preferred time",
+                    selection: preferredTimeBinding,
+                    displayedComponents: .hourAndMinute
+                )
+                .disabled(!practiceNudgesEnabled)
+            } footer: {
+                Text("Choose when practice reminders should appear. RiyaazPal will schedule your reminder after setup finishes.")
+            }
+
+            Section {
+                HStack {
+                    Text("Permission")
+                    Spacer()
+                    Text(permissionText)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .background(Color("AppBackground"))
+        .scrollContentBackground(.hidden)
+        .navigationTitle("Practice Nudges")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await refreshAuthorizationStatus()
+            if authorizationStatus == .denied {
+                practiceNudgesEnabled = false
+                PracticeNudgeNotificationService.cancelDailyNudge()
+            }
+        }
+    }
+}
+
+private extension PracticeNudgeOnboardingView {
+
+    var preferredTimeBinding: Binding<Date> {
+        Binding(
+            get: {
+                Calendar.current.date(
+                    bySettingHour: practiceNudgeHour,
+                    minute: practiceNudgeMinute,
+                    second: 0,
+                    of: Date()
+                ) ?? Date()
+            },
+            set: { date in
+                let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+                practiceNudgeHour = components.hour ?? practiceNudgeHour
+                practiceNudgeMinute = components.minute ?? practiceNudgeMinute
+            }
+        )
+    }
+
+    var permissionText: String {
+        switch authorizationStatus {
+        case .notDetermined:
+            return "Not requested"
+        case .denied:
+            return "Off"
+        case .authorized:
+            return "Allowed"
+        case .provisional:
+            return "Provisional"
+        case .ephemeral:
+            return "Temporary"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+
+    func handleNudgeToggle(_ isEnabled: Bool) {
+        guard isEnabled else {
+            practiceNudgesEnabled = false
+            PracticeNudgeNotificationService.cancelDailyNudge()
+            return
+        }
+
+        Task {
+            await requestNotificationPermission()
+        }
+    }
+
+    func refreshAuthorizationStatus() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        authorizationStatus = settings.authorizationStatus
+    }
+
+    func requestNotificationPermission() async {
+        isRequestingPermission = true
+        defer { isRequestingPermission = false }
+
+        do {
+            let granted = try await UNUserNotificationCenter.current().requestAuthorization(
+                options: [.alert, .badge, .sound]
+            )
+            await refreshAuthorizationStatus()
+            practiceNudgesEnabled = granted
+            if !granted {
+                PracticeNudgeNotificationService.cancelDailyNudge()
+            }
+        } catch {
+            practiceNudgesEnabled = false
+            PracticeNudgeNotificationService.cancelDailyNudge()
+            await refreshAuthorizationStatus()
+        }
+    }
+}
+
+#Preview("Practice Nudge Onboarding") {
+    NavigationStack {
+        PracticeNudgeOnboardingView()
+    }
+}

--- a/RiyaazPal/Views/Setup/SetupView.swift
+++ b/RiyaazPal/Views/Setup/SetupView.swift
@@ -64,7 +64,7 @@ struct SetupView: View {
                 }
 
         case .notifications:
-            PracticeNudgeSettingsView()
+            PracticeNudgeOnboardingView()
                 .safeAreaInset(edge: .bottom) {
                     setupStepControls(
                         primaryTitle: "Continue",


### PR DESCRIPTION
This prevents the onboarding notification step from querying restored practice ratings while iCloud sync is still settling, avoiding a SwiftData crash on fresh installs with existing iCloud data.

