### PR TITLE
feature/implement KVS mirror to speed up onboarding for previous user

### DIFF
--- a/RiyaazPal.xcodeproj/project.pbxproj
+++ b/RiyaazPal.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		C0864B292FB2000006E5F6A /* PracticeNudgeNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B282FB2000006E5F6A /* PracticeNudgeNotificationService.swift */; };
 		C0864B2B2FB3000006E5F6A /* PracticeNudgeNotificationRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B2A2FB3000006E5F6A /* PracticeNudgeNotificationRouting.swift */; };
 		C0864B2D2FB5000006E5F6A /* PracticeAreaFocusBreakdownCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B2C2FB5000006E5F6A /* PracticeAreaFocusBreakdownCard.swift */; };
+		C0864B332FC6000006E5F6A /* PracticeAreaSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864B322FC6000006E5F6A /* PracticeAreaSnapshotStore.swift */; };
 		C091E6352F42580200271B6E /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C091E6342F42580200271B6E /* FilterChip.swift */; };
 		C091E6372F425D1200271B6E /* PracticeTimelineTypeEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C091E6362F425D1200271B6E /* PracticeTimelineTypeEmptyState.swift */; };
 		C0A430BD2F03494200C2401C /* RiyaazPalApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A430BC2F03494200C2401C /* RiyaazPalApp.swift */; };
@@ -105,6 +106,7 @@
 		C0864B282FB2000006E5F6A /* PracticeNudgeNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeNudgeNotificationService.swift; sourceTree = "<group>"; };
 		C0864B2A2FB3000006E5F6A /* PracticeNudgeNotificationRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeNudgeNotificationRouting.swift; sourceTree = "<group>"; };
 		C0864B2C2FB5000006E5F6A /* PracticeAreaFocusBreakdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreaFocusBreakdownCard.swift; sourceTree = "<group>"; };
+		C0864B322FC6000006E5F6A /* PracticeAreaSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreaSnapshotStore.swift; sourceTree = "<group>"; };
 		C091E6342F42580200271B6E /* FilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChip.swift; sourceTree = "<group>"; };
 		C091E6362F425D1200271B6E /* PracticeTimelineTypeEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimelineTypeEmptyState.swift; sourceTree = "<group>"; };
 		C0A430B92F03494200C2401C /* RiyaazPal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RiyaazPal.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -173,6 +175,7 @@
 				C0864B222FAE0000006E5F6A /* PracticeRecommendationService.swift */,
 				C0864B282FB2000006E5F6A /* PracticeNudgeNotificationService.swift */,
 				C0864B2A2FB3000006E5F6A /* PracticeNudgeNotificationRouting.swift */,
+				C0864B322FC6000006E5F6A /* PracticeAreaSnapshotStore.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -447,6 +450,7 @@
 				C066A2922F0F3DF9005A5D44 /* InsightWindow.swift in Sources */,
 				C0E580482F1A493B00571C5E /* EditSessionDetailedNotesEditor.swift in Sources */,
 				C0A430E82F08A25C00C2401C /* TagChip.swift in Sources */,
+				C0864B332FC6000006E5F6A /* PracticeAreaSnapshotStore.swift in Sources */,
 				C0D82F152F249E2E00B4E0E8 /* SetupView.swift in Sources */,
 				C0D82F172F249F4200B4E0E8 /* Preferences.swift in Sources */,
 				C0A430DB2F059A0600C2401C /* DaySection.swift in Sources */,

--- a/RiyaazPal/Analytics/PracticeAreaSnapshotStore.swift
+++ b/RiyaazPal/Analytics/PracticeAreaSnapshotStore.swift
@@ -67,7 +67,7 @@ enum PracticeAreaSnapshotStore {
         }
 
         var didChangeLocalStore = false
-        let existingAreasByID = Dictionary(uniqueKeysWithValues: existingAreas.map { ($0.id, $0) })
+        let existingAreasByID = newestAreasByID(from: existingAreas)
 
         for snapshot in incomingSnapshots {
             if let area = existingAreasByID[snapshot.id] {
@@ -97,6 +97,22 @@ enum PracticeAreaSnapshotStore {
         }
 
         return didChangeLocalStore
+    }
+
+    @MainActor
+    private static func newestAreasByID(
+        from areas: [PracticeAreaEntity]
+    ) -> [UUID: PracticeAreaEntity] {
+        areas.reduce(into: [:]) { partialResult, area in
+            guard let existingArea = partialResult[area.id] else {
+                partialResult[area.id] = area
+                return
+            }
+
+            if area.lastModified > existingArea.lastModified {
+                partialResult[area.id] = area
+            }
+        }
     }
 }
 

--- a/RiyaazPal/Analytics/PracticeAreaSnapshotStore.swift
+++ b/RiyaazPal/Analytics/PracticeAreaSnapshotStore.swift
@@ -1,0 +1,133 @@
+//
+//  PracticeAreaSnapshotStore.swift
+//  RiyaazPal
+//
+//  Created by Hriday Buddhdev on 2026-06-02.
+//
+
+import Foundation
+import SwiftData
+
+struct PracticeAreaSnapshot: Codable, Equatable {
+    let id: UUID
+    let name: String
+    let createdAt: Date
+    let isActive: Bool
+    let order: Int
+    let lastModified: Date
+}
+
+enum PracticeAreaSnapshotStore {
+    private static let snapshotsKey = "practiceAreaSnapshots.v1"
+    private static let store = NSUbiquitousKeyValueStore.default
+
+    @discardableResult
+    static func synchronize() -> Bool {
+        store.synchronize()
+    }
+
+    static func snapshots() -> [PracticeAreaSnapshot] {
+        synchronize()
+
+        guard let data = store.data(forKey: snapshotsKey) else {
+            return []
+        }
+
+        do {
+            return try JSONDecoder().decode([PracticeAreaSnapshot].self, from: data)
+        } catch {
+            print("PracticeAreaSnapshotStore.snapshots decode error:", error)
+            return []
+        }
+    }
+
+    @MainActor
+    static func save(areas: [PracticeAreaEntity]) {
+        let snapshots = areas.map(PracticeAreaSnapshot.init(area:))
+
+        do {
+            let data = try JSONEncoder().encode(snapshots)
+            store.set(data, forKey: snapshotsKey)
+            synchronize()
+        } catch {
+            print("PracticeAreaSnapshotStore.save encode error:", error)
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    static func restoreInto(
+        context: ModelContext,
+        existingAreas: [PracticeAreaEntity]
+    ) -> Bool {
+        let incomingSnapshots = snapshots()
+
+        guard !incomingSnapshots.isEmpty else {
+            return false
+        }
+
+        var didChangeLocalStore = false
+        let existingAreasByID = Dictionary(uniqueKeysWithValues: existingAreas.map { ($0.id, $0) })
+
+        for snapshot in incomingSnapshots {
+            if let area = existingAreasByID[snapshot.id] {
+                guard snapshot.lastModified > area.lastModified else {
+                    continue
+                }
+
+                snapshot.apply(to: area)
+                didChangeLocalStore = true
+            } else {
+                context.insert(PracticeAreaEntity(snapshot: snapshot))
+                didChangeLocalStore = true
+            }
+        }
+
+        if didChangeLocalStore {
+            do {
+                try context.save()
+            } catch {
+                print("PracticeAreaSnapshotStore.restore save error:", error)
+                return false
+            }
+        }
+
+        if !existingAreas.isEmpty {
+            save(areas: existingAreas)
+        }
+
+        return didChangeLocalStore
+    }
+}
+
+private extension PracticeAreaSnapshot {
+    init(area: PracticeAreaEntity) {
+        self.id = area.id
+        self.name = area.name
+        self.createdAt = area.createdAt
+        self.isActive = area.isActive
+        self.order = area.order
+        self.lastModified = area.lastModified
+    }
+
+    func apply(to area: PracticeAreaEntity) {
+        area.name = name
+        area.createdAt = createdAt
+        area.isActive = isActive
+        area.order = order
+        area.lastModified = lastModified
+    }
+}
+
+private extension PracticeAreaEntity {
+    convenience init(snapshot: PracticeAreaSnapshot) {
+        self.init(
+            id: snapshot.id,
+            name: snapshot.name,
+            createdAt: snapshot.createdAt,
+            isActive: snapshot.isActive,
+            order: snapshot.order,
+            lastModified: snapshot.lastModified
+        )
+    }
+}

--- a/RiyaazPal/Info.plist
+++ b/RiyaazPal/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/RiyaazPal/Models/PracticeAreaModel.swift
+++ b/RiyaazPal/Models/PracticeAreaModel.swift
@@ -17,19 +17,22 @@ final class PracticeAreaEntity {
     var createdAt: Date = Date.now
     var isActive: Bool = true
     var order: Int = 0
+    var lastModified: Date = Date.now
 
     init(
         id: UUID = UUID(),
         name: String,
         createdAt: Date = .now,
         isActive: Bool = true,
-        order: Int = 0
+        order: Int = 0,
+        lastModified: Date? = nil
     ) {
         self.id = id
         self.name = name
         self.createdAt = createdAt
         self.isActive = isActive
         self.order = order
+        self.lastModified = lastModified ?? createdAt
     }
 }
 

--- a/RiyaazPal/RiyaazPal.entitlements
+++ b/RiyaazPal/RiyaazPal.entitlements
@@ -10,5 +10,7 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)com.hridaybuddhdev.RiyaazPal</string>
 </dict>
 </plist>

--- a/RiyaazPal/RiyaazPalApp.swift
+++ b/RiyaazPal/RiyaazPalApp.swift
@@ -27,7 +27,9 @@ struct RiyaazPalApp: App {
                 RootTabView()
                     .environmentObject(tabRouter)
             } else {
-                SetupView()
+                PracticeAreaRestoreGateView {
+                    SetupView()
+                }
             }
         }
         .modelContainer(RiyaazPalModelContainer.shared)
@@ -104,6 +106,8 @@ struct RootTabView: View {
                 if practiceNudgesEnabled {
                     PracticeNudgeRefreshTask()
                 }
+
+                PracticeAreaSnapshotSyncTask()
             }
 
             iCloudSyncStatusBanner
@@ -147,6 +151,135 @@ struct RootTabView: View {
             .transition(.move(edge: .top).combined(with: .opacity))
             .animation(.spring(response: 0.28, dampingFraction: 0.9), value: iCloudSyncStatusMonitor.isSyncing)
         }
+    }
+}
+
+private struct PracticeAreaRestoreGateView<Content: View>: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @Query(sort: \PracticeAreaEntity.order)
+    private var practiceAreas: [PracticeAreaEntity]
+
+    @AppStorage("hasCompletedSetup")
+    private var hasCompletedSetup = false
+
+    @State private var isCheckingCloudMirror = true
+
+    let content: () -> Content
+
+    var body: some View {
+        Group {
+            if isCheckingCloudMirror {
+                VStack(spacing: 12) {
+                    ProgressView()
+
+                    Text("Checking iCloud")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Color("SecondaryText"))
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color("AppBackground"))
+            } else {
+                content()
+            }
+        }
+        .task {
+            await restorePracticeAreasIfAvailable()
+        }
+    }
+}
+
+private extension PracticeAreaRestoreGateView {
+    @MainActor
+    func restorePracticeAreasIfAvailable() async {
+        guard isCheckingCloudMirror else { return }
+
+        if !practiceAreas.isEmpty {
+            PracticeAreaSnapshotStore.save(areas: practiceAreas)
+            hasCompletedSetup = true
+            return
+        }
+
+        if PracticeAreaSnapshotStore.restoreInto(
+            context: modelContext,
+            existingAreas: practiceAreas
+        ) {
+            hasCompletedSetup = true
+            return
+        }
+
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        if !practiceAreas.isEmpty {
+            PracticeAreaSnapshotStore.save(areas: practiceAreas)
+            hasCompletedSetup = true
+            return
+        }
+
+        if PracticeAreaSnapshotStore.restoreInto(
+            context: modelContext,
+            existingAreas: practiceAreas
+        ) {
+            hasCompletedSetup = true
+            return
+        }
+
+        isCheckingCloudMirror = false
+    }
+}
+
+private struct PracticeAreaSnapshotSyncTask: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @Query(sort: \PracticeAreaEntity.order)
+    private var practiceAreas: [PracticeAreaEntity]
+
+    @State private var lastMirroredSignature = ""
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .task {
+                mirrorPracticeAreasIfNeeded()
+            }
+            .onChange(of: practiceAreasSignature) {
+                mirrorPracticeAreasIfNeeded()
+            }
+    }
+}
+
+private extension PracticeAreaSnapshotSyncTask {
+    var practiceAreasSignature: String {
+        practiceAreas
+            .map { area in
+                [
+                    area.id.uuidString,
+                    area.name,
+                    area.isActive.description,
+                    area.order.description,
+                    area.lastModified.timeIntervalSinceReferenceDate.description
+                ].joined(separator: "|")
+            }
+            .joined(separator: ";")
+    }
+
+    @MainActor
+    func mirrorPracticeAreasIfNeeded() {
+        guard !practiceAreas.isEmpty else { return }
+
+        let signature = practiceAreasSignature
+        guard signature != lastMirroredSignature else { return }
+
+        lastMirroredSignature = signature
+
+        if PracticeAreaSnapshotStore.restoreInto(
+            context: modelContext,
+            existingAreas: practiceAreas
+        ) {
+            return
+        }
+
+        PracticeAreaSnapshotStore.save(areas: practiceAreas)
     }
 }
 

--- a/RiyaazPal/ViewModels/PracticeAreasViewModel.swift
+++ b/RiyaazPal/ViewModels/PracticeAreasViewModel.swift
@@ -53,12 +53,15 @@ final class PracticeAreasViewModel: ObservableObject {
             named: trimmed,
             currentAreas: currentAreas
         ) {
+            let now = Date.now
             archivedArea.name = trimmed
             archivedArea.isActive = true
             archivedArea.order = nextOrder
+            archivedArea.lastModified = now
 
             do {
                 try context.save()
+                mirrorPracticeAreas()
                 return archivedArea
             } catch {
                 print("PracticeAreasViewModel.createArea reactivate error:", error)
@@ -75,6 +78,7 @@ final class PracticeAreasViewModel: ObservableObject {
 
         do {
             try context.save()
+            mirrorPracticeAreas()
             return area
         } catch {
             print("PracticeAreasViewModel.createArea error:", error)
@@ -107,9 +111,11 @@ final class PracticeAreasViewModel: ObservableObject {
         }
 
         area.name = trimmed
+        area.lastModified = Date.now
 
         do {
             try context.save()
+            mirrorPracticeAreas()
             return true
         } catch {
             print("PracticeAreasViewModel.renameArea error:", error)
@@ -122,9 +128,11 @@ final class PracticeAreasViewModel: ObservableObject {
         guard let context else { return }
 
         area.isActive = false
+        area.lastModified = Date.now
 
         do {
             try context.save()
+            mirrorPracticeAreas()
         } catch {
             print("PracticeAreasViewModel.deactivateArea error:", error)
         }
@@ -153,11 +161,14 @@ final class PracticeAreasViewModel: ObservableObject {
                 .max() ?? -1
         ) + 1
 
+        let now = Date.now
         area.isActive = true
         area.order = nextOrder
+        area.lastModified = now
 
         do {
             try context.save()
+            mirrorPracticeAreas()
             return true
         } catch {
             print("PracticeAreasViewModel.reactivateArea error:", error)
@@ -176,12 +187,15 @@ final class PracticeAreasViewModel: ObservableObject {
         var reordered = activeAreas
         reordered.move(fromOffsets: source, toOffset: destination)
 
+        let now = Date.now
         for (index, area) in reordered.enumerated() {
             area.order = index
+            area.lastModified = now
         }
 
         do {
             try context.save()
+            mirrorPracticeAreas()
         } catch {
             print("PracticeAreasViewModel.moveAreas error:", error)
         }
@@ -222,5 +236,17 @@ private extension PracticeAreasViewModel {
             area.id != id &&
             normalizedKey(area.name) == key
         }
+    }
+
+    @MainActor
+    func mirrorPracticeAreas() {
+        guard let context else { return }
+
+        let descriptor = FetchDescriptor<PracticeAreaEntity>(
+            sortBy: [SortDescriptor(\.order)]
+        )
+        let areas = (try? context.fetch(descriptor)) ?? []
+
+        PracticeAreaSnapshotStore.save(areas: areas)
     }
 }


### PR DESCRIPTION
Adds KVS mirror to quickly restore config (practice areas) from icloud. previously restoring user data all at once took over 20 seconds to retrieve practice areas - implementing a KVS mirror brings this down to about 2-5 seconds. 

Conflict handling using simple last-write-wins, keyed by stable `PracticeAreaEntity.id`.