### PR TITLE
Feature/practice area tests

### DIFF
--- a/RiyaazPal.xcodeproj/project.pbxproj
+++ b/RiyaazPal.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C0DE01002FD1000000000001 /* PracticeAreaMetricsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE01022FD1000000000001 /* PracticeAreaMetricsCalculatorTests.swift */; };
+		C0DE01012FD1000000000001 /* PracticeAreaFocusBreakdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE01032FD1000000000001 /* PracticeAreaFocusBreakdownTests.swift */; };
 		C00066902F0EF8D500BC930C /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C000668F2F0EF8D500BC930C /* InsightsView.swift */; };
 		C00066932F0F101000BC930C /* PracticeScoreMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00066922F0F101000BC930C /* PracticeScoreMeter.swift */; };
 		C04482E32F273BD700068D74 /* SetupWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04482E22F273BD700068D74 /* SetupWelcomeView.swift */; };
@@ -73,7 +75,20 @@
 		C0DE00112FDB000000000001 /* TestDataSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00102FDB000000000001 /* TestDataSeeder.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		C0DE010A2FD1000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C0A430B12F03494200C2401C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C0A430B82F03494200C2401C;
+			remoteInfo = RiyaazPal;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		C0DE01022FD1000000000001 /* PracticeAreaMetricsCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreaMetricsCalculatorTests.swift; sourceTree = "<group>"; };
+		C0DE01032FD1000000000001 /* PracticeAreaFocusBreakdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeAreaFocusBreakdownTests.swift; sourceTree = "<group>"; };
+		C0DE01042FD1000000000001 /* RiyaazPalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RiyaazPalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C000668F2F0EF8D500BC930C /* InsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
 		C00066922F0F101000BC930C /* PracticeScoreMeter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeScoreMeter.swift; sourceTree = "<group>"; };
 		C04482E22F273BD700068D74 /* SetupWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupWelcomeView.swift; sourceTree = "<group>"; };
@@ -144,6 +159,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		C0DE01082FD1000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C0A430B62F03494200C2401C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -193,6 +215,7 @@
 			children = (
 				C066A2A52F159D25005A5D44 /* Config */,
 				C0A430BB2F03494200C2401C /* RiyaazPal */,
+				C0DE01052FD1000000000001 /* RiyaazPalTests */,
 				C0A430BA2F03494200C2401C /* Products */,
 			);
 			sourceTree = "<group>";
@@ -201,6 +224,7 @@
 			isa = PBXGroup;
 			children = (
 				C0A430B92F03494200C2401C /* RiyaazPal.app */,
+				C0DE01042FD1000000000001 /* RiyaazPalTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -221,6 +245,15 @@
 				C0A430C22F03494400C2401C /* Preview Content */,
 			);
 			path = RiyaazPal;
+			sourceTree = "<group>";
+		};
+		C0DE01052FD1000000000001 /* RiyaazPalTests */ = {
+			isa = PBXGroup;
+			children = (
+				C0DE01022FD1000000000001 /* PracticeAreaMetricsCalculatorTests.swift */,
+				C0DE01032FD1000000000001 /* PracticeAreaFocusBreakdownTests.swift */,
+			);
+			path = RiyaazPalTests;
 			sourceTree = "<group>";
 		};
 		C0A430C22F03494400C2401C /* Preview Content */ = {
@@ -366,6 +399,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		C0DE01062FD1000000000001 /* RiyaazPalTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C0DE010E2FD1000000000001 /* Build configuration list for PBXNativeTarget "RiyaazPalTests" */;
+			buildPhases = (
+				C0DE01072FD1000000000001 /* Sources */,
+				C0DE01082FD1000000000001 /* Frameworks */,
+				C0DE01092FD1000000000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C0DE010B2FD1000000000001 /* PBXTargetDependency */,
+			);
+			name = RiyaazPalTests;
+			productName = RiyaazPalTests;
+			productReference = C0DE01042FD1000000000001 /* RiyaazPalTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C0A430B82F03494200C2401C /* RiyaazPal */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C0A430C72F03494400C2401C /* Build configuration list for PBXNativeTarget "RiyaazPal" */;
@@ -401,6 +452,10 @@
 							};
 						};
 					};
+					C0DE01062FD1000000000001 = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = C0A430B82F03494200C2401C;
+					};
 				};
 			};
 			buildConfigurationList = C0A430B42F03494200C2401C /* Build configuration list for PBXProject "RiyaazPal" */;
@@ -417,11 +472,19 @@
 			projectRoot = "";
 			targets = (
 				C0A430B82F03494200C2401C /* RiyaazPal */,
+				C0DE01062FD1000000000001 /* RiyaazPalTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		C0DE01092FD1000000000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C0A430B72F03494200C2401C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -434,6 +497,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		C0DE01072FD1000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0DE01002FD1000000000001 /* PracticeAreaMetricsCalculatorTests.swift in Sources */,
+				C0DE01012FD1000000000001 /* PracticeAreaFocusBreakdownTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C0A430B52F03494200C2401C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -505,7 +577,63 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		C0DE010B2FD1000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C0A430B82F03494200C2401C /* RiyaazPal */;
+			targetProxy = C0DE010A2FD1000000000001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		C0DE010C2FD1000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 65QCBL5R9T;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hridaybuddhdev.RiyaazPalTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RiyaazPal.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RiyaazPal";
+			};
+			name = Debug;
+		};
+		C0DE010D2FD1000000000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 65QCBL5R9T;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hridaybuddhdev.RiyaazPalTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RiyaazPal.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RiyaazPal";
+			};
+			name = Release;
+		};
 		C0A430C52F03494400C2401C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -689,6 +817,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		C0DE010E2FD1000000000001 /* Build configuration list for PBXNativeTarget "RiyaazPalTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C0DE010C2FD1000000000001 /* Debug */,
+				C0DE010D2FD1000000000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C0A430B42F03494200C2401C /* Build configuration list for PBXProject "RiyaazPal" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/RiyaazPal.xcodeproj/xcshareddata/xcschemes/RiyaazPal.xcscheme
+++ b/RiyaazPal.xcodeproj/xcshareddata/xcschemes/RiyaazPal.xcscheme
@@ -29,6 +29,15 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0A430B82F03494200C2401C"
+            BuildableName = "RiyaazPal.app"
+            BlueprintName = "RiyaazPal"
+            ReferencedContainer = "container:RiyaazPal.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -42,15 +51,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "C0A430B82F03494200C2401C"
-            BuildableName = "RiyaazPal.app"
-            BlueprintName = "RiyaazPal"
-            ReferencedContainer = "container:RiyaazPal.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/RiyaazPal.xcodeproj/xcshareddata/xcschemes/RiyaazPal.xcscheme
+++ b/RiyaazPal.xcodeproj/xcshareddata/xcschemes/RiyaazPal.xcscheme
@@ -29,6 +29,28 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C0DE01062FD1000000000001"
+               BuildableName = "RiyaazPalTests.xctest"
+               BlueprintName = "RiyaazPalTests"
+               ReferencedContainer = "container:RiyaazPal.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0A430B82F03494200C2401C"
+            BuildableName = "RiyaazPal.app"
+            BlueprintName = "RiyaazPal"
+            ReferencedContainer = "container:RiyaazPal.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/RiyaazPal/Views/Insights/PracticeAreaFocusBreakdownCard.swift
+++ b/RiyaazPal/Views/Insights/PracticeAreaFocusBreakdownCard.swift
@@ -437,7 +437,7 @@ private struct PracticeAreaFocusLegendRow: View {
     }
 }
 
-private enum PracticeAreaFocusPercentageFormatter {
+enum PracticeAreaFocusPercentageFormatter {
     static func text(count: Int, totalCount: Int) -> String {
         guard totalCount > 0 else { return "0%" }
 
@@ -450,13 +450,13 @@ private enum PracticeAreaFocusPercentageFormatter {
     }
 }
 
-private struct PracticeAreaFocusSlice: Identifiable {
+struct PracticeAreaFocusSlice: Identifiable {
     let id: String
     let name: String
     let count: Int
 }
 
-private extension PracticeAreaFocusSlice {
+extension PracticeAreaFocusSlice {
     static func slices(from metrics: [PracticeAreaMetric]) -> [PracticeAreaFocusSlice] {
         metrics
             .filter(\.isActive)

--- a/RiyaazPalTests/PracticeAreaFocusBreakdownTests.swift
+++ b/RiyaazPalTests/PracticeAreaFocusBreakdownTests.swift
@@ -1,0 +1,111 @@
+//
+//  PracticeAreaFocusBreakdownTests.swift
+//  RiyaazPalTests
+//
+//  Created by Hriday Buddhdev on 2026-06-02.
+//
+
+import XCTest
+@testable import RiyaazPal
+
+final class PracticeAreaFocusBreakdownTests: XCTestCase {
+    func testSlicesIncludeOnlyActiveAreasWithPracticeRatings() {
+        let slices = PracticeAreaFocusSlice.slices(
+            from: [
+                metric(id: "alap", name: "Alap", isActive: true, practiceCount: 4),
+                metric(id: "taans", name: "Taans", isActive: true, practiceCount: 2),
+                metric(id: "archived", name: "Archived", isActive: false, practiceCount: 10),
+                metric(id: "empty", name: "Empty", isActive: true, practiceCount: 0)
+            ]
+        )
+
+        XCTAssertEqual(slices.map(\.name), ["Alap", "Taans"])
+        XCTAssertEqual(slices.map(\.count), [4, 2])
+    }
+
+    func testSlicesSortTiesByAreaName() {
+        let slices = PracticeAreaFocusSlice.slices(
+            from: [
+                metric(id: "layakari", name: "Layakari", practiceCount: 3),
+                metric(id: "alap", name: "Alap", practiceCount: 3),
+                metric(id: "taans", name: "Taans", practiceCount: 5)
+            ]
+        )
+
+        XCTAssertEqual(slices.map(\.name), ["Taans", "Alap", "Layakari"])
+    }
+
+    func testCompactDisplaySlicesKeepsTopFourAndGroupsTheRest() {
+        let slices = [
+            PracticeAreaFocusSlice(id: "one", name: "One", count: 9),
+            PracticeAreaFocusSlice(id: "two", name: "Two", count: 8),
+            PracticeAreaFocusSlice(id: "three", name: "Three", count: 7),
+            PracticeAreaFocusSlice(id: "four", name: "Four", count: 6),
+            PracticeAreaFocusSlice(id: "five", name: "Five", count: 5),
+            PracticeAreaFocusSlice(id: "six", name: "Six", count: 4)
+        ]
+
+        let compactSlices = PracticeAreaFocusSlice.compactDisplaySlices(from: slices)
+
+        XCTAssertEqual(compactSlices.map(\.name), ["One", "Two", "Three", "Four", "Other"])
+        XCTAssertEqual(compactSlices.last?.count, 9)
+    }
+
+    func testPercentageFormatterShowsLessThanOnePercentForTinyNonZeroSlices() {
+        XCTAssertEqual(
+            PracticeAreaFocusPercentageFormatter.text(count: 1, totalCount: 1_000),
+            "<1%"
+        )
+        XCTAssertEqual(
+            PracticeAreaFocusPercentageFormatter.text(count: 0, totalCount: 1_000),
+            "0%"
+        )
+        XCTAssertEqual(
+            PracticeAreaFocusPercentageFormatter.text(count: 6, totalCount: 10),
+            "60%"
+        )
+    }
+}
+
+private extension PracticeAreaFocusBreakdownTests {
+    func metric(
+        id: String,
+        name: String,
+        isActive: Bool = true,
+        practiceCount: Int
+    ) -> PracticeAreaMetric {
+        PracticeAreaMetric(
+            id: id,
+            areaID: UUID(),
+            areaName: name,
+            isActive: isActive,
+            latestScore: nil,
+            sevenDayAverage: nil,
+            previousSevenDayAverage: nil,
+            thirtyDayAverage: nil,
+            trendDirection: .insufficientData,
+            ratedSessionCount: practiceCount,
+            daysSincePracticed: nil,
+            isNeglected: false,
+            volatility: nil,
+            practice: PracticeAreaContextMetric(
+                latestScore: nil,
+                averageScore: nil,
+                ratedSessionCount: practiceCount,
+                volatility: nil
+            ),
+            concert: PracticeAreaContextMetric(
+                latestScore: nil,
+                averageScore: nil,
+                ratedSessionCount: 0,
+                volatility: nil
+            ),
+            performanceTransfer: PracticeAreaPerformanceTransfer(
+                practiceAverage: nil,
+                concertAverage: nil,
+                delta: nil,
+                status: .insufficientData
+            )
+        )
+    }
+}

--- a/RiyaazPalTests/PracticeAreaMetricsCalculatorTests.swift
+++ b/RiyaazPalTests/PracticeAreaMetricsCalculatorTests.swift
@@ -1,0 +1,264 @@
+//
+//  PracticeAreaMetricsCalculatorTests.swift
+//  RiyaazPalTests
+//
+//  Created by Hriday Buddhdev on 2026-06-02.
+//
+
+import XCTest
+@testable import RiyaazPal
+
+final class PracticeAreaMetricsCalculatorTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    func testImprovingTrendComparesSevenDayWindows() throws {
+        let areaID = UUID()
+        let now = try date("2026-06-02T12:00:00Z")
+
+        let metrics = compute(
+            areaID: areaID,
+            now: now,
+            scores: [
+                score(5, daysAgo: 10, areaID: areaID),
+                score(7, daysAgo: 2, areaID: areaID)
+            ]
+        )
+
+        let metric = try XCTUnwrap(metrics.first)
+        XCTAssertEqual(metric.trendDirection, .improving)
+        XCTAssertEqual(metric.sevenDayAverage, 7)
+        XCTAssertEqual(metric.previousSevenDayAverage, 5)
+    }
+
+    func testMissedPracticeIsNeglectedWithoutDecliningTrend() throws {
+        let areaID = UUID()
+        let now = try date("2026-06-02T12:00:00Z")
+
+        let metrics = compute(
+            areaID: areaID,
+            now: now,
+            scores: [
+                score(8, daysAgo: 8, areaID: areaID)
+            ]
+        )
+
+        let metric = try XCTUnwrap(metrics.first)
+        XCTAssertNil(metric.sevenDayAverage)
+        XCTAssertEqual(metric.previousSevenDayAverage, 8)
+        XCTAssertEqual(metric.trendDirection, .insufficientData)
+        XCTAssertEqual(metric.daysSincePracticed, 8)
+        XCTAssertTrue(metric.isNeglected)
+    }
+
+    func testPerformanceTransferDetectsConcertDrop() throws {
+        let areaID = UUID()
+        let now = try date("2026-06-02T12:00:00Z")
+
+        let metrics = compute(
+            areaID: areaID,
+            now: now,
+            scores: [
+                score(8, daysAgo: 7, areaID: areaID),
+                score(8, daysAgo: 6, areaID: areaID),
+                score(9, daysAgo: 5, areaID: areaID),
+                score(9, daysAgo: 4, areaID: areaID),
+                score(6, daysAgo: 3, areaID: areaID, sessionType: .concert),
+                score(6, daysAgo: 2, areaID: areaID, sessionType: .concert),
+                score(6, daysAgo: 1, areaID: areaID, sessionType: .concert)
+            ]
+        )
+
+        let transfer = try XCTUnwrap(metrics.first?.performanceTransfer)
+        XCTAssertEqual(try XCTUnwrap(transfer.practiceAverage), 8.5)
+        XCTAssertEqual(try XCTUnwrap(transfer.concertAverage), 6)
+        XCTAssertEqual(try XCTUnwrap(transfer.delta), -2.5)
+        XCTAssertEqual(transfer.status, .significantDrop)
+    }
+
+    func testPerformanceTransferDetectsMaintainedConcertExecution() throws {
+        let areaID = UUID()
+        let now = try date("2026-06-02T12:00:00Z")
+
+        let metrics = compute(
+            areaID: areaID,
+            now: now,
+            scores: [
+                score(7, daysAgo: 7, areaID: areaID),
+                score(8, daysAgo: 6, areaID: areaID),
+                score(8, daysAgo: 5, areaID: areaID),
+                score(9, daysAgo: 4, areaID: areaID),
+                score(7, daysAgo: 3, areaID: areaID, sessionType: .concert),
+                score(8, daysAgo: 2, areaID: areaID, sessionType: .concert),
+                score(8, daysAgo: 1, areaID: areaID, sessionType: .concert)
+            ]
+        )
+
+        let transfer = try XCTUnwrap(metrics.first?.performanceTransfer)
+        XCTAssertEqual(try XCTUnwrap(transfer.practiceAverage), 8)
+        XCTAssertEqual(
+            try XCTUnwrap(transfer.concertAverage),
+            7.666666666666667,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(transfer.status, .maintained)
+    }
+
+    func testUsesNewestRatingWhenSessionHasDuplicateAreaRatings() throws {
+        let areaID = UUID()
+        let sessionID = UUID()
+        let now = try date("2026-06-02T12:00:00Z")
+        let sessionDate = try date("2026-06-01T12:00:00Z")
+
+        let sessions = [
+            session(id: sessionID, startTime: sessionDate, sessionType: .practice)
+        ]
+        let ratings = [
+            rating(
+                sessionID: sessionID,
+                areaID: areaID,
+                areaName: "Alap",
+                score: 4,
+                createdAt: sessionDate,
+                lastModified: try date("2026-06-01T12:05:00Z")
+            ),
+            rating(
+                sessionID: sessionID,
+                areaID: areaID,
+                areaName: "Alap",
+                score: 9,
+                createdAt: sessionDate,
+                lastModified: try date("2026-06-01T12:10:00Z")
+            )
+        ]
+
+        let metrics = PracticeAreaMetricsCalculator.compute(
+            practiceAreas: [area(id: areaID, name: "Alap")],
+            ratings: ratings,
+            sessions: sessions,
+            now: now,
+            calendar: calendar
+        )
+
+        let metric = try XCTUnwrap(metrics.first)
+        XCTAssertEqual(metric.latestScore, 9)
+        XCTAssertEqual(metric.ratedSessionCount, 1)
+        XCTAssertEqual(metric.practice.averageScore, 9)
+    }
+}
+
+private extension PracticeAreaMetricsCalculatorTests {
+    struct ScoreFixture {
+        let score: Int
+        let daysAgo: Int
+        let areaID: UUID
+        let sessionType: SessionType
+    }
+
+    func compute(
+        areaID: UUID,
+        now: Date,
+        scores: [ScoreFixture]
+    ) -> [PracticeAreaMetric] {
+        let sessions = scores.enumerated().map { index, fixture in
+            session(
+                id: sessionID(index),
+                startTime: calendar.date(
+                    byAdding: .day,
+                    value: -fixture.daysAgo,
+                    to: now
+                ) ?? now,
+                sessionType: fixture.sessionType
+            )
+        }
+
+        let ratings = zip(scores.indices, scores).map { index, fixture in
+            let sessionDate = sessions[index].startTime
+            return rating(
+                sessionID: sessionID(index),
+                areaID: fixture.areaID,
+                areaName: "Alap",
+                score: fixture.score,
+                createdAt: sessionDate,
+                lastModified: sessionDate
+            )
+        }
+
+        return PracticeAreaMetricsCalculator.compute(
+            practiceAreas: [area(id: areaID, name: "Alap")],
+            ratings: ratings,
+            sessions: sessions,
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    func score(
+        _ value: Int,
+        daysAgo: Int,
+        areaID: UUID,
+        sessionType: SessionType = .practice
+    ) -> ScoreFixture {
+        ScoreFixture(
+            score: value,
+            daysAgo: daysAgo,
+            areaID: areaID,
+            sessionType: sessionType
+        )
+    }
+
+    func area(
+        id: UUID,
+        name: String,
+        isActive: Bool = true,
+        order: Int = 0
+    ) -> PracticeAreaMetricAreaInput {
+        PracticeAreaMetricAreaInput(
+            id: id,
+            name: name,
+            isActive: isActive,
+            order: order
+        )
+    }
+
+    func session(
+        id: UUID,
+        startTime: Date,
+        sessionType: SessionType
+    ) -> PracticeAreaMetricSessionInput {
+        PracticeAreaMetricSessionInput(
+            id: id,
+            startTime: startTime,
+            duration: 45 * 60,
+            sessionType: sessionType,
+            lastModified: startTime
+        )
+    }
+
+    func rating(
+        sessionID: UUID,
+        areaID: UUID,
+        areaName: String,
+        score: Int,
+        createdAt: Date,
+        lastModified: Date
+    ) -> PracticeAreaMetricRatingInput {
+        PracticeAreaMetricRatingInput(
+            sessionID: sessionID,
+            practiceAreaID: areaID,
+            areaName: areaName,
+            didPractice: true,
+            score: score,
+            createdAt: createdAt,
+            lastModified: lastModified
+        )
+    }
+
+    func sessionID(_ index: Int) -> UUID {
+        UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012d", index + 1))")!
+    }
+
+    func date(_ string: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        return try XCTUnwrap(formatter.date(from: string))
+    }
+}


### PR DESCRIPTION
Added the following unit tests: 

**PracticeAreaMetricsCalculatorTests**

- Verifies improving trend detection when the recent 7-day average is meaningfully higher than the previous 7-day average.
- Verifies missed practice is treated as neglect/inactivity, not as a false declining trend.
- Verifies concert execution is flagged as a significant drop when concert average is more than 1.5 below practice average.
- Verifies concert execution is marked maintained when concert and practice averages are within the maintained threshold.
- Verifies duplicate ratings for the same area/session use the newest lastModified rating.

**PracticeAreaFocusBreakdownTests**

- Verifies focus mix excludes archived areas and active areas with zero practice ratings.
- Verifies focus slices sort by count first, then alphabetically for ties.
- Verifies focus mix keeps the top 4 areas and groups the rest into “Other”.
- Verifies tiny non-zero percentages display as <1% instead of 0%.
