### PR TITLE
Bug/Open edit view after ending live practice

### DIFF
--- a/RiyaazPal/Views/Timeline/PracticeTimelineView.swift
+++ b/RiyaazPal/Views/Timeline/PracticeTimelineView.swift
@@ -159,6 +159,7 @@ private extension PracticeTimelineView {
                 context.insert(session)
                 do {
                     try context.save()
+                    selectedSession = session
                 } catch {
                     // TODO: alert if failed to save
                     print("Failed to save session: \(error.localizedDescription)")


### PR DESCRIPTION
Set `selectedSession` when logging a live session so the session editor opens immediately 